### PR TITLE
feat(claude): add Claude Code config with setup commands and git hooks

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,5 +1,8 @@
 .secrets
 
+# Documentation files — keep in repo, don't deploy to $HOME
+.claude/README.md
+
 # Only apply PowerShell scripts on Windows
 {{- if ne .chezmoi.os "windows" }}
 run_once_install-packages-windows.ps1

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -11,12 +11,14 @@ This directory (`home/dot_claude/`) maps to `~/.claude/` when chezmoi applies do
 ## Repository Architecture
 
 The parent dotfiles repo uses **chezmoi** with `.chezmoiroot` set to `home/`, meaning files in `home/` map to `$HOME`. Chezmoi naming conventions:
+
 - `dot_` prefix = `.` in target (e.g., `dot_zshrc` -> `~/.zshrc`)
 - `.tmpl` suffix = Go template processed with data from `.chezmoi.toml`
 - `run_once_` prefix = script runs once per machine
 - `run_onchange_` prefix = script re-runs when its contents (or watched files) change
 
 Key paths relative to repo root:
+
 - `.chezmoi.toml` — config data (user info, package lists per platform)
 - `home/` — all managed dotfiles and scripts
 - `home/dot_claude/` — this directory, Claude Code config
@@ -27,6 +29,7 @@ Key paths relative to repo root:
 ## CI/CD and Linting
 
 CI runs on push/PR to `main` via `.github/workflows/ci.yml`:
+
 - **ShellCheck** on `scripts/` and `home/`
 - **markdownlint-cli2** on all `*.md` files (config: `.markdownlint.yaml`)
 - **actionlint** on GitHub Actions workflows
@@ -42,6 +45,7 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
 ## Claude Code Config Architecture (This Directory)
 
 The design separates concerns by context cost:
+
 - **Slash commands** (`/setup-python`, etc.) — loaded only when invoked, set up language tooling
 - **Hooks** — run tools automatically (pre-commit, formatters) with zero context cost
 - **CLAUDE.md** — lean universal policy, always loaded

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+This is a subdirectory of a **chezmoi-managed dotfiles repository** (`/Users/paul/dev/dotfiles`). The full repo provisions a development environment across macOS, Linux (Ubuntu/Debian), WSL, and Windows.
+
+This directory (`home/dot_claude/`) maps to `~/.claude/` when chezmoi applies dotfiles. It contains centralized Claude Code configuration (hooks, slash commands, policy) intended for use across all repositories.
+
+## Repository Architecture
+
+The parent dotfiles repo uses **chezmoi** with `.chezmoiroot` set to `home/`, meaning files in `home/` map to `$HOME`. Chezmoi naming conventions:
+- `dot_` prefix = `.` in target (e.g., `dot_zshrc` -> `~/.zshrc`)
+- `.tmpl` suffix = Go template processed with data from `.chezmoi.toml`
+- `run_once_` prefix = script runs once per machine
+- `run_onchange_` prefix = script re-runs when its contents (or watched files) change
+
+Key paths relative to repo root:
+- `.chezmoi.toml` — config data (user info, package lists per platform)
+- `home/` — all managed dotfiles and scripts
+- `home/dot_claude/` — this directory, Claude Code config
+- `scripts/` — validation scripts for CI
+- `specs/` — feature specifications
+- `docs/` — documentation (testing, maintenance, troubleshooting, migration)
+
+## CI/CD and Linting
+
+CI runs on push/PR to `main` via `.github/workflows/ci.yml`:
+- **ShellCheck** on `scripts/` and `home/`
+- **markdownlint-cli2** on all `*.md` files (config: `.markdownlint.yaml`)
+- **actionlint** on GitHub Actions workflows
+- **Test Install** matrix: Ubuntu, macOS, Windows — runs `chezmoi init --apply` then validation scripts
+
+Pre-commit hooks (`.pre-commit-config.yaml`) run markdownlint-cli2.
+
+## Commit Style
+
+Conventional commits: `<type>(<scope>): <description>`
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
+
+## Claude Code Config Architecture (This Directory)
+
+The design separates concerns by context cost:
+- **Slash commands** (`/setup-python`, etc.) — loaded only when invoked, set up language tooling
+- **Hooks** — run tools automatically (pre-commit, formatters) with zero context cost
+- **CLAUDE.md** — lean universal policy, always loaded
+
+See `README.md` in this directory for the full implementation plan including enforcement layers and per-language tool matrices.

--- a/home/dot_claude/README.md
+++ b/home/dot_claude/README.md
@@ -1,0 +1,152 @@
+# Claude Code Configuration
+
+Centralized configuration for Claude Code across all repositories — hooks, slash commands, and language-specific setup templates.
+
+## Design Principle
+
+When linting, formatting, and security tools are configured, they become the enforcement mechanism. Claude Code doesn't need to *know* your standards — it just sees failures and fixes them.
+
+This configuration separates **one-time setup** from **ongoing enforcement**, keeping context costs low:
+
+| Concern | Solution | Context Cost |
+|---------|----------|--------------|
+| Setting up a new project | Slash commands (`/setup-python`) | Loaded only when invoked |
+| Enforcing standards during coding | Hooks that run tools automatically | Zero — tool output is the context |
+| High-level policy | Lean CLAUDE.md | ~20-30 lines |
+
+## Enforcement Layers
+
+Checks are enforced at three layers, from most authoritative to most immediate. Higher layers are always-on and catch everything; lower layers are optional optimizations that provide faster feedback.
+
+### Layer 1: CI (Always Enforced)
+
+CI runs on every push/PR. This is the **source of truth** — nothing merges without passing. Each `/setup-*` slash command includes a CI workflow snippet for the relevant language.
+
+### Layer 2: Git Pre-commit Hooks
+
+Pre-commit hooks run the same checks locally before code leaves the developer's machine. They catch issues earlier than CI and reduce round-trips. The `/setup-common` command installs the [pre-commit](https://pre-commit.com/) framework, and each language command registers its tools into it.
+
+### Layer 3: Claude Code Hooks (Optional Optimization)
+
+Claude Code hooks provide **immediate feedback during editing**. Only use these for tools that are fast, deterministic, and auto-fix — so Claude doesn't waste turns on formatting.
+
+**Good candidates for file-level hooks (PostToolUse):**
+
+- Formatters in fix mode (ruff format, prettier, rustfmt, gofmt)
+- Fast linters with auto-fix (ruff check --fix, eslint --fix)
+
+**Keep at pre-commit / CI only:**
+
+- Type checkers (mypy, pyright, tsc) — need full project context
+- Security scanners (bandit, trivy) — slow, project-wide
+- Complex linters (golangci-lint with many checks) — too slow per-file
+
+## Tooling Matrix
+
+Each `/setup-*` slash command configures the tools listed below. All commands are **additive and composable** — run `/setup-common` first for the foundation, then stack any combination.
+
+| Language | Formatting | Linting | Type Checking | Security | Deps Audit |
+|----------|-----------|---------|---------------|----------|------------|
+| **Common** | — | — | — | gitleaks | — |
+| **Markdown** | prettier | markdownlint-cli2 | — | — | — |
+| **Shell** | — | shellcheck | — | — | — |
+| **Docker** | — | hadolint | — | trivy | — |
+| **Terraform** | terraform fmt | tflint, terraform validate | — | tfsec / trivy, checkov | — |
+| **Go** | gofmt / goimports | golangci-lint | — | — | govulncheck |
+| **Python** | ruff | ruff | mypy / pyright | bandit | pip-audit |
+| **.NET / C#** | dotnet format | Roslyn analyzers | — | SecurityCodeScan | dotnet outdated |
+| **Rust** | rustfmt | clippy | — | — | cargo-audit, cargo-deny |
+| **Java** | google-java-format / spotless | checkstyle, SpotBugs, PMD | — | — | OWASP dependency-check |
+| **Ruby** | rubocop | rubocop | — | brakeman | bundler-audit |
+| **PHP** | PHP-CS-Fixer / PHP_CodeSniffer | PHPStan / Psalm | — | — | composer audit |
+| **Node.js** | prettier | eslint | — | — | npm audit |
+| **TypeScript** | prettier | eslint + typescript-eslint | tsc --noEmit | — | npm audit |
+
+### Which Layer Runs What
+
+| Tool Category | CI | Pre-commit | Claude Hook |
+|---------------|:--:|:----------:|:-----------:|
+| Formatters | yes | yes | yes (auto-fix on write) |
+| Fast linters | yes | yes | optional (auto-fix on write) |
+| Type checkers | yes | yes | no |
+| Security scanners | yes | yes | no |
+| Dependency audits | yes | no | no |
+
+## Directory Structure
+
+```
+~/.claude/
+├── settings.json              # Universal hooks (runs on every repo)
+├── CLAUDE.md                  # Universal policy (loaded on every repo)
+└── commands/
+    ├── setup-common.md        # Shared tooling (pre-commit, gitleaks)
+    ├── setup-shell.md
+    ├── setup-markdown.md
+    ├── setup-docker.md
+    ├── setup-terraform.md
+    ├── setup-go.md
+    ├── setup-python.md
+    ├── setup-dotnet.md
+    ├── setup-rust.md
+    ├── setup-java.md
+    ├── setup-ruby.md
+    ├── setup-php.md
+    ├── setup-node.md
+    └── setup-typescript.md
+```
+
+## Slash Commands
+
+Each `/setup-*` command contains:
+
+1. Tool installation commands
+2. Configuration file contents
+3. Pre-commit hook registration
+4. CI workflow snippet
+
+**New project setup:**
+
+```
+/setup-common
+/setup-python
+```
+
+**Day-to-day coding:**
+Claude Code edits files -> hooks auto-run -> Claude sees failures -> fixes them. No context spent on rules — tooling output *is* the context.
+
+## Hook Configuration Examples
+
+**Pre-commit hook (Layer 2):**
+
+```json
+{
+  "hooks": {
+    "PreCommit": [
+      {
+        "command": "pre-commit run --all-files 2>&1 | tail -40"
+      }
+    ]
+  }
+}
+```
+
+**File-level auto-fix (Layer 3):**
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "write_file|edit_file|create_file",
+        "command": "prettier --write $CLAUDE_FILE_PATHS 2>&1 | tail -5"
+      }
+    ]
+  }
+}
+```
+
+## Customization
+
+- **Project overrides**: Add `.claude/settings.json` in any repo to extend/override user-level hooks
+- **Subdirectory context**: Add `CLAUDE.md` files in subdirectories for monorepo language-specific context
+- **New languages**: Copy an existing setup command and adapt the tool list

--- a/home/dot_claude/README.md
+++ b/home/dot_claude/README.md
@@ -9,7 +9,7 @@ When linting, formatting, and security tools are configured, they become the enf
 This configuration separates **one-time setup** from **ongoing enforcement**, keeping context costs low:
 
 | Concern | Solution | Context Cost |
-|---------|----------|--------------|
+| ------- | -------- | ------------ |
 | Setting up a new project | Slash commands (`/setup-python`) | Loaded only when invoked |
 | Enforcing standards during coding | Hooks that run tools automatically | Zero — tool output is the context |
 | High-level policy | Lean CLAUDE.md | ~20-30 lines |
@@ -46,7 +46,7 @@ Claude Code hooks provide **immediate feedback during editing**. Only use these 
 Each `/setup-*` slash command configures the tools listed below. All commands are **additive and composable** — run `/setup-common` first for the foundation, then stack any combination.
 
 | Language | Formatting | Linting | Type Checking | Security | Deps Audit |
-|----------|-----------|---------|---------------|----------|------------|
+| -------- | ---------- | ------- | ------------- | -------- | ---------- |
 | **Common** | — | — | — | gitleaks | — |
 | **Markdown** | prettier | markdownlint-cli2 | — | — | — |
 | **Shell** | shfmt | shellcheck | — | — | — |
@@ -65,7 +65,7 @@ Each `/setup-*` slash command configures the tools listed below. All commands ar
 ### Which Layer Runs What
 
 | Tool Category | CI | Pre-commit | Claude Hook |
-|---------------|:--:|:----------:|:-----------:|
+| ------------- | :-: | :--------: | :---------: |
 | Formatters | yes | yes | yes (auto-fix on write) |
 | Fast linters | yes | yes | optional (auto-fix on write) |
 | Type checkers | yes | yes | no |
@@ -74,7 +74,7 @@ Each `/setup-*` slash command configures the tools listed below. All commands ar
 
 ## Directory Structure
 
-```
+```text
 ~/.claude/
 ├── settings.json              # Universal hooks (runs on every repo)
 ├── CLAUDE.md                  # Universal policy (loaded on every repo)
@@ -106,7 +106,7 @@ Each `/setup-*` command contains:
 
 **New project setup:**
 
-```
+```text
 /setup-common
 /setup-python
 ```

--- a/home/dot_claude/README.md
+++ b/home/dot_claude/README.md
@@ -51,9 +51,9 @@ Each `/setup-*` slash command configures the tools listed below. All commands ar
 | **Markdown** | prettier | markdownlint-cli2 | — | — | — |
 | **Shell** | — | shellcheck | — | — | — |
 | **Docker** | — | hadolint | — | trivy | — |
-| **Terraform** | terraform fmt | tflint, terraform validate | — | tfsec / trivy, checkov | — |
+| **Terraform** | terraform fmt | tflint, terraform validate | — | tfsec, checkov | — |
 | **Go** | gofmt / goimports | golangci-lint | — | — | govulncheck |
-| **Python** | ruff | ruff | mypy / pyright | bandit | pip-audit |
+| **Python** | ruff | ruff | mypy / pyright | bandit | — |
 | **.NET / C#** | dotnet format | Roslyn analyzers | — | SecurityCodeScan | dotnet outdated |
 | **Rust** | rustfmt | clippy | — | — | cargo-audit, cargo-deny |
 | **Java** | google-java-format / spotless | checkstyle, SpotBugs, PMD | — | — | OWASP dependency-check |

--- a/home/dot_claude/README.md
+++ b/home/dot_claude/README.md
@@ -49,7 +49,7 @@ Each `/setup-*` slash command configures the tools listed below. All commands ar
 |----------|-----------|---------|---------------|----------|------------|
 | **Common** | — | — | — | gitleaks | — |
 | **Markdown** | prettier | markdownlint-cli2 | — | — | — |
-| **Shell** | — | shellcheck | — | — | — |
+| **Shell** | shfmt | shellcheck | — | — | — |
 | **Docker** | — | hadolint | — | trivy | — |
 | **Terraform** | terraform fmt | tflint, terraform validate | — | tfsec, checkov | — |
 | **Go** | gofmt / goimports | golangci-lint | — | — | govulncheck |

--- a/home/dot_claude/commands/setup-common.md
+++ b/home/dot_claude/commands/setup-common.md
@@ -1,0 +1,65 @@
+Set up the common development tooling foundation for this project. This is the base layer that language-specific setup commands build on.
+
+## What to install and configure
+
+### 1. EditorConfig
+
+Create `.editorconfig` in the project root (if it doesn't already exist). If one exists, review it and suggest additions for any missing settings.
+
+```ini
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.{go,py}]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+```
+
+### 2. pre-commit framework
+
+Create `.pre-commit-config.yaml` in the project root (if it doesn't already exist). If one exists, review it and suggest adding any missing hooks from below.
+
+```yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: <latest tag>
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: <latest tag>
+    hooks:
+      - id: gitleaks
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+After creating/updating the config, run:
+
+```sh
+pre-commit install
+```
+
+If `pre-commit` is not installed, tell the user to install it (`brew install pre-commit`) and stop.
+
+### 3. Verify
+
+Run `pre-commit run --all-files` to confirm everything works. Fix any issues that come up.
+
+## Important
+
+- Do NOT blindly overwrite existing config files. Read them first and merge.
+- If a `.gitignore` doesn't exist, create one appropriate for the project.

--- a/home/dot_claude/commands/setup-docker.md
+++ b/home/dot_claude/commands/setup-docker.md
@@ -1,0 +1,82 @@
+Set up Docker linting and security scanning for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. Hadolint
+
+Create `.hadolint.yaml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```yaml
+ignored:
+  - DL3008  # Pin versions in apt-get install
+  - DL3018  # Pin versions in apk add
+
+trustedRegistries:
+  - docker.io
+  - gcr.io
+  - ghcr.io
+```
+
+### 2. .gitignore
+
+No Docker-specific entries needed. Confirm `/setup-common` has already created a `.gitignore` with the standard entries.
+
+### 3. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/hadolint/hadolint
+    rev: <latest tag>
+    hooks:
+      - id: hadolint-docker
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include Docker linting and security scanning jobs that only run when Dockerfiles change. Use a separate workflow file (e.g., `.github/workflows/docker.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Docker
+on:
+  push:
+    paths: ['**/Dockerfile*', '**/docker-compose*.yml']
+  pull_request:
+    paths: ['**/Dockerfile*', '**/docker-compose*.yml']
+
+jobs:
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scanners: 'misconfig'
+```
+
+Don't duplicate if Docker lint jobs already exist. Look up latest action versions.
+
+If the project builds container images, suggest also adding an image scan step that runs `trivy image` after the build.
+
+### 5. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- If the project has multiple Dockerfiles, configure hadolint-action to scan all of them.

--- a/home/dot_claude/commands/setup-dotnet.md
+++ b/home/dot_claude/commands/setup-dotnet.md
@@ -1,0 +1,141 @@
+Set up .NET / C# linting, formatting, and security scanning for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. EditorConfig for C#
+
+Append C#-specific settings to `.editorconfig` (merge with existing):
+
+```ini
+[*.cs]
+indent_size = 4
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+dotnet_sort_system_directives_first = true
+
+# Naming conventions
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_prefix.capitalization = camel_case
+dotnet_naming_style.underscore_prefix.required_prefix = _
+```
+
+### 2. Directory.Build.props (Roslyn analyzers + SecurityCodeScan)
+
+Create or update `Directory.Build.props` in the solution root:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+```
+
+Look up the latest stable version of `SecurityCodeScan.VS2019` (or `SecurityCodeScan.VS2022` for .NET 8+) and pin it instead of `*`.
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# .NET
+bin/
+obj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+packages/
+*.nupkg
+project.lock.json
+```
+
+### 4. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/dotnet/format
+    rev: <latest tag>
+    hooks:
+      - id: dotnet-format
+        args: ['--verbosity', 'minimal']
+```
+
+If no pre-commit hook is available for `dotnet format`, use a local hook instead:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: dotnet-format
+        name: dotnet format
+        entry: dotnet format --verbosity minimal
+        language: system
+        types: [c#]
+```
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include .NET build, lint, and security scanning jobs that only run when C# files change. Use a separate workflow file (e.g., `.github/workflows/dotnet.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: .NET
+on:
+  push:
+    paths: ['**/*.cs', '**/*.csproj', '**/*.sln', 'Directory.Build.props']
+  pull_request:
+    paths: ['**/*.cs', '**/*.csproj', '**/*.sln', 'Directory.Build.props']
+
+jobs:
+  build-and-lint:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet restore
+      - run: dotnet build --no-restore /p:TreatWarningsAsErrors=true
+      - run: dotnet format --verify-no-changes --verbosity minimal
+
+  outdated:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet tool install --global dotnet-outdated-tool
+      - run: dotnet outdated
+```
+
+Adjust `dotnet-version` to match the project. Don't duplicate if .NET build jobs already exist. Look up latest action versions.
+
+### 6. Verify
+
+Run `dotnet build` to confirm analyzers are active and no warnings are emitted. Run `dotnet format --verify-no-changes` to confirm formatting.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- If the project uses a `.sln` file, ensure `dotnet format` targets the solution.
+- Adjust the .NET SDK version in CI to match the project's target framework.

--- a/home/dot_claude/commands/setup-dotnet.md
+++ b/home/dot_claude/commands/setup-dotnet.md
@@ -2,7 +2,7 @@ Set up .NET / C# linting, formatting, and security scanning for this project. As
 
 ## What to install and configure
 
-### 1. EditorConfig for C#
+### 1. EditorConfig for CSharp
 
 Append C#-specific settings to `.editorconfig` (merge with existing):
 

--- a/home/dot_claude/commands/setup-go.md
+++ b/home/dot_claude/commands/setup-go.md
@@ -1,0 +1,80 @@
+Set up Go linting, formatting, and security scanning for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. golangci-lint
+
+Create `.golangci.yml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```yaml
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - gosimple
+    - ineffassign
+    - typecheck
+    - goimports
+    - revive
+    - misspell
+    - gosec
+
+linters-settings:
+  goimports:
+    local-prefixes: # Leave empty — user should set to their module path
+  revive:
+    rules:
+      - name: exported
+        severity: warning
+
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+run:
+  timeout: 5m
+```
+
+Tell the user to set `local-prefixes` under `goimports` to their Go module path.
+
+### 2. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/golangci/golangci-lint
+    rev: <latest tag>
+    hooks:
+      - id: golangci-lint
+
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: <latest tag>
+    hooks:
+      - id: go-fumpt
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+### 3. govulncheck
+
+Check if `govulncheck` is installed (`go install golang.org/x/vuln/cmd/govulncheck@latest`). If not, tell the user to install it. It's run manually or in CI, not as a pre-commit hook (too slow).
+
+Suggest adding to CI:
+
+```yaml
+- name: Run govulncheck
+  run: govulncheck ./...
+```
+
+### 4. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- If there's no `go.mod`, warn the user — Go tooling requires a module.

--- a/home/dot_claude/commands/setup-java.md
+++ b/home/dot_claude/commands/setup-java.md
@@ -1,0 +1,166 @@
+Set up Java linting, formatting, and dependency auditing for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. google-java-format / spotless
+
+If the project uses **Gradle**, add the Spotless plugin to `build.gradle` or `build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("com.diffplug.spotless") version "<latest>"
+}
+
+spotless {
+    java {
+        googleJavaFormat()
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+```
+
+If the project uses **Maven**, add the Spotless plugin to `pom.xml`:
+
+```xml
+<plugin>
+    <groupId>com.diffplug.spotless</groupId>
+    <artifactId>spotless-maven-plugin</artifactId>
+    <version>LATEST</version>
+    <configuration>
+        <java>
+            <googleJavaFormat/>
+            <removeUnusedImports/>
+            <trimTrailingWhitespace/>
+            <endWithNewline/>
+        </java>
+    </configuration>
+</plugin>
+```
+
+Look up the latest stable version of the Spotless plugin.
+
+### 2. Checkstyle
+
+Create `checkstyle.xml` in the project root (if it doesn't already exist) or use Google's published config:
+
+```xml
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="GoogleStyle"/>
+    </module>
+</module>
+```
+
+For most projects, using the Google style checkstyle config via Spotless is sufficient. Only add standalone checkstyle if the project has custom rules.
+
+### 3. SpotBugs / PMD
+
+If the project uses Gradle, add:
+
+```kotlin
+plugins {
+    id("com.github.spotbugs") version "<latest>"
+    id("pmd")
+}
+
+pmd {
+    isConsoleOutput = true
+    ruleSetFiles = files("pmd-ruleset.xml")
+}
+```
+
+If these are too noisy for an existing codebase, start with Spotless formatting only and add linters incrementally.
+
+### 4. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Java
+*.class
+*.jar
+*.war
+*.ear
+target/
+build/
+.gradle/
+out/
+*.iml
+.idea/
+```
+
+### 5. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: spotless-check
+        name: spotless check
+        entry: ./gradlew spotlessCheck
+        language: system
+        types: [java]
+        pass_filenames: false
+```
+
+For Maven projects, use `mvn spotless:check` as the entry instead.
+
+### 6. GitHub Actions workflow
+
+Create or update the CI workflow to include Java linting and dependency auditing jobs that only run when Java files change. Use a separate workflow file (e.g., `.github/workflows/java.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Java
+on:
+  push:
+    paths: ['**/*.java', 'build.gradle*', 'pom.xml', 'settings.gradle*']
+  pull_request:
+    paths: ['**/*.java', 'build.gradle*', 'pom.xml', 'settings.gradle*']
+
+jobs:
+  lint:
+    name: Spotless & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - run: ./gradlew spotlessCheck
+      - run: ./gradlew check
+
+  dependency-check:
+    name: OWASP Dependency Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: dependency-check/Dependency-Check_Action@main
+        with:
+          project: '${{ github.repository }}'
+          path: '.'
+          format: 'HTML'
+```
+
+Adjust for Maven if the project uses `pom.xml` instead of Gradle. Don't duplicate if Java lint jobs already exist. Look up latest action versions.
+
+### 7. Verify
+
+Run `./gradlew spotlessCheck` (or `mvn spotless:check`) to confirm formatting. Fix any issues with `./gradlew spotlessApply`.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- Ask the user whether the project uses Gradle or Maven before configuring.
+- Adjust the Java version in CI to match the project's target.

--- a/home/dot_claude/commands/setup-markdown.md
+++ b/home/dot_claude/commands/setup-markdown.md
@@ -57,7 +57,35 @@ Append these repos to the existing `.pre-commit-config.yaml`:
 
 Look up the latest release tag for each repo and use those for the `rev:` values.
 
-### 4. Verify
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include a markdown lint job that only runs when markdown files change.
+
+```yaml
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+```
+
+Add a path filter on the workflow trigger so this job only runs when relevant files change:
+
+```yaml
+on:
+  push:
+    paths: ['**/*.md']
+  pull_request:
+    paths: ['**/*.md']
+```
+
+If there's already a CI workflow with broader triggers, add the job there and use a job-level `if` with `github.event.pull_request` changed files, or create a separate workflow file (e.g., `.github/workflows/markdown.yml`) with the path filter. Don't duplicate if a markdown lint job already exists.
+
+### 5. Verify
 
 Run `pre-commit run --all-files` to confirm. Fix any markdown lint issues that surface.
 

--- a/home/dot_claude/commands/setup-markdown.md
+++ b/home/dot_claude/commands/setup-markdown.md
@@ -1,0 +1,67 @@
+Set up markdown linting and formatting for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. markdownlint-cli2
+
+Create `.markdownlint.yaml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```yaml
+# Default state for all rules
+default: true
+
+# MD013 - Line length
+MD013: false
+
+# MD033 - Inline HTML
+MD033: false
+
+# MD041 - First line should be a top-level heading
+MD041: false
+```
+
+### 2. Prettier (markdown formatting)
+
+Add markdown configuration to `.prettierrc` (create if needed, merge if exists):
+
+```json
+{
+  "proseWrap": "always",
+  "printWidth": 120,
+  "tabWidth": 2
+}
+```
+
+Create `.prettierignore` if it doesn't exist:
+
+```text
+CHANGELOG.md
+```
+
+### 3. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: <latest tag>
+    hooks:
+      - id: markdownlint-cli2
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: <latest tag>
+    hooks:
+      - id: prettier
+        types_or: [markdown]
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+### 4. Verify
+
+Run `pre-commit run --all-files` to confirm. Fix any markdown lint issues that surface.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.

--- a/home/dot_claude/commands/setup-node.md
+++ b/home/dot_claude/commands/setup-node.md
@@ -1,0 +1,138 @@
+Set up Node.js linting, formatting, and dependency auditing for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. Prettier (formatting)
+
+Create `.prettierrc` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```json
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}
+```
+
+Create `.prettierignore` if it doesn't exist:
+
+```text
+node_modules/
+dist/
+build/
+coverage/
+```
+
+### 2. ESLint
+
+Create `eslint.config.js` (flat config) in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```js
+import js from '@eslint/js';
+
+export default [
+  js.configs.recommended,
+  {
+    rules: {
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-console': 'warn',
+      'prefer-const': 'error',
+      'no-var': 'error',
+    },
+  },
+  {
+    ignores: ['node_modules/', 'dist/', 'build/', 'coverage/'],
+  },
+];
+```
+
+If the project uses CommonJS (no `"type": "module"` in `package.json`), use `eslint.config.cjs` with `require()` instead.
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Node.js
+node_modules/
+dist/
+build/
+coverage/
+*.tgz
+.npm
+.eslintcache
+```
+
+### 4. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: <latest tag>
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: <latest tag>
+    hooks:
+      - id: eslint
+        types: [javascript]
+        additional_dependencies:
+          - eslint
+          - '@eslint/js'
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include Node.js linting and dependency auditing jobs that only run when JS files change. Use a separate workflow file (e.g., `.github/workflows/node.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Node.js
+on:
+  push:
+    paths: ['**/*.js', '**/*.mjs', '**/*.cjs', 'package.json', 'package-lock.json']
+  pull_request:
+    paths: ['**/*.js', '**/*.mjs', '**/*.cjs', 'package.json', 'package-lock.json']
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prettier --check .
+      - run: npx eslint .
+
+  audit:
+    name: npm Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+      - run: npm audit --audit-level=high
+```
+
+If the project doesn't have `.node-version`, use a fixed `node-version: '22'` (or whatever the project uses). Don't duplicate if Node.js lint jobs already exist. Look up latest action versions.
+
+### 6. Verify
+
+Run `npx prettier --check .` and `npx eslint .` to confirm. Fix formatting issues with `npx prettier --write .`.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- Use ESLint flat config format (eslint.config.js) for new projects. If the project has an existing `.eslintrc.*`, don't migrate unless asked.
+- If the project uses yarn or pnpm instead of npm, adjust commands and CI accordingly.

--- a/home/dot_claude/commands/setup-php.md
+++ b/home/dot_claude/commands/setup-php.md
@@ -1,0 +1,136 @@
+Set up PHP linting, formatting, and dependency auditing for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. PHP-CS-Fixer (formatting)
+
+Create `.php-cs-fixer.dist.php` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('vendor');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'no_unused_imports' => true,
+        'trailing_comma_in_multiline' => true,
+        'single_quote' => true,
+    ])
+    ->setFinder($finder);
+```
+
+### 2. PHPStan (static analysis)
+
+Create `phpstan.neon` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```neon
+parameters:
+    level: 6
+    paths:
+        - src
+    excludePaths:
+        - vendor
+```
+
+Adjust `paths` and `level` to match the project. Level 6 is a good starting point; level 9 is maximum strictness. For existing codebases, start lower and increase incrementally.
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# PHP
+vendor/
+composer.lock
+.phpunit.result.cache
+.php-cs-fixer.cache
+phpstan-baseline.neon
+```
+
+Note: `composer.lock` should be committed for applications but may be ignored for libraries. Ask the user which type this project is and adjust accordingly.
+
+### 4. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: php-cs-fixer
+        name: php-cs-fixer
+        entry: vendor/bin/php-cs-fixer fix --dry-run --diff
+        language: system
+        types: [php]
+        pass_filenames: false
+      - id: phpstan
+        name: phpstan
+        entry: vendor/bin/phpstan analyse
+        language: system
+        types: [php]
+        pass_filenames: false
+```
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include PHP linting and dependency auditing jobs that only run when PHP files change. Use a separate workflow file (e.g., `.github/workflows/php.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: PHP
+on:
+  push:
+    paths: ['**/*.php', 'composer.json', 'composer.lock', 'phpstan.neon']
+  pull_request:
+    paths: ['**/*.php', 'composer.json', 'composer.lock', 'phpstan.neon']
+
+jobs:
+  lint:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --no-progress
+      - run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --no-progress
+      - run: vendor/bin/phpstan analyse
+
+  audit:
+    name: Composer Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer audit
+```
+
+Adjust `php-version` to match the project. Don't duplicate if PHP lint jobs already exist. Look up latest action versions.
+
+### 6. Verify
+
+Run `vendor/bin/php-cs-fixer fix --dry-run --diff` and `vendor/bin/phpstan analyse` to confirm. Fix any issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- If the project uses Psalm instead of PHPStan, substitute accordingly.
+- Adjust the PHP version in CI to match the project's minimum supported version.

--- a/home/dot_claude/commands/setup-python.md
+++ b/home/dot_claude/commands/setup-python.md
@@ -1,0 +1,164 @@
+Set up Python linting, formatting, type checking, and security scanning for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+Use `uv` for all Python package management. Never use `pip install` or `pipx` directly.
+
+## What to install and configure
+
+### 1. ruff (formatting + linting)
+
+Add ruff configuration to `pyproject.toml` (create if needed, merge if exists):
+
+```toml
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "S",    # flake8-bandit (security)
+    "RUF",  # ruff-specific rules
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]  # Allow assert in tests
+```
+
+Adjust `target-version` to match the project's minimum Python version.
+
+### 2. mypy (type checking)
+
+Add mypy configuration to `pyproject.toml`:
+
+```toml
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+```
+
+Adjust `python_version` to match the project. If `strict = true` is too aggressive for an existing codebase, start with:
+
+```toml
+[tool.mypy]
+python_version = "3.12"
+check_untyped_defs = true
+disallow_untyped_defs = false
+```
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.venv/
+venv/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+htmlcov/
+coverage.xml
+.coverage
+```
+
+### 4. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: <latest tag>
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: <latest tag>
+    hooks:
+      - id: mypy
+        additional_dependencies: []  # Add project deps that have type stubs
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+The `additional_dependencies` list in the mypy hook should include any packages that provide type stubs needed by the project (e.g., `types-requests`).
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include Python linting, type checking, and security scanning jobs that only run when Python files change. Use a separate workflow file (e.g., `.github/workflows/python.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Python
+on:
+  push:
+    paths: ['**/*.py', 'pyproject.toml', 'uv.lock']
+  pull_request:
+    paths: ['**/*.py', 'pyproject.toml', 'uv.lock']
+
+jobs:
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+
+  typecheck:
+    name: Mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: uv run mypy .
+
+  security:
+    name: Bandit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv tool run bandit -r . -c pyproject.toml
+```
+
+Don't duplicate if Python lint jobs already exist. Look up latest action versions.
+
+### 6. Bandit configuration
+
+Add bandit configuration to `pyproject.toml`:
+
+```toml
+[tool.bandit]
+exclude_dirs = ["tests", ".venv", "venv"]
+skips = []
+```
+
+### 7. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or type issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- Always use `uv` for Python package management, never `pip` directly.
+- If the project uses `pyright` instead of `mypy`, substitute accordingly.
+- Note that ruff's `S` rules overlap with bandit. Having both is intentional — ruff catches issues inline during editing, bandit provides deeper analysis in CI.

--- a/home/dot_claude/commands/setup-ruby.md
+++ b/home/dot_claude/commands/setup-ruby.md
@@ -1,0 +1,123 @@
+Set up Ruby linting, formatting, and security scanning for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. RuboCop (formatting + linting)
+
+Create `.rubocop.yml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```yaml
+require:
+  - rubocop-performance
+  - rubocop-rake
+
+AllCops:
+  TargetRubyVersion: 3.3
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - 'vendor/**/*'
+    - 'db/schema.rb'
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 20
+
+Layout/LineLength:
+  Max: 120
+```
+
+Adjust `TargetRubyVersion` to match the project. If the project uses Rails, add `rubocop-rails` to the require list.
+
+### 2. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Ruby
+*.gem
+*.rbc
+.bundle/
+vendor/bundle/
+coverage/
+tmp/
+log/
+.byebug_history
+```
+
+### 3. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/rubocop/rubocop
+    rev: <latest tag>
+    hooks:
+      - id: rubocop
+        args: ['--auto-correct']
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include Ruby linting and security scanning jobs that only run when Ruby files change. Use a separate workflow file (e.g., `.github/workflows/ruby.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Ruby
+on:
+  push:
+    paths: ['**/*.rb', 'Gemfile', 'Gemfile.lock', '.rubocop.yml']
+  pull_request:
+    paths: ['**/*.rb', 'Gemfile', 'Gemfile.lock', '.rubocop.yml']
+
+jobs:
+  rubocop:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rubocop
+
+  brakeman:
+    name: Brakeman
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: gem install brakeman
+      - run: brakeman --no-pager
+
+  bundler-audit:
+    name: Bundler Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: gem install bundler-audit
+      - run: bundle-audit check --update
+```
+
+Don't duplicate if Ruby lint jobs already exist. Look up latest action versions.
+
+Brakeman is only relevant for Rails applications. If the project is not a Rails app, skip the brakeman job.
+
+### 5. Verify
+
+Run `bundle exec rubocop` to confirm. Fix any issues with `bundle exec rubocop --auto-correct`.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- If the project uses Rails, add `rubocop-rails` to the RuboCop config and Gemfile.
+- Only include brakeman for Rails applications.

--- a/home/dot_claude/commands/setup-rust.md
+++ b/home/dot_claude/commands/setup-rust.md
@@ -1,0 +1,160 @@
+Set up Rust linting, formatting, and dependency auditing for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. rustfmt
+
+Create `rustfmt.toml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```toml
+edition = "2021"
+max_width = 100
+use_field_init_shorthand = true
+use_try_shorthand = true
+```
+
+Adjust `edition` to match `Cargo.toml`.
+
+### 2. clippy
+
+Create `clippy.toml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```toml
+too-many-arguments-threshold = 7
+```
+
+Add clippy configuration to `Cargo.toml` or `.cargo/config.toml`:
+
+```toml
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+unwrap_used = "warn"
+expect_used = "warn"
+```
+
+If `pedantic` is too aggressive for an existing codebase, start with the default clippy lints and add selectively.
+
+### 3. deny.toml (cargo-deny)
+
+Create `deny.toml` in the project root (if it doesn't already exist):
+
+```toml
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+```
+
+### 4. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Rust
+target/
+Cargo.lock
+```
+
+Note: `Cargo.lock` should be committed for binary crates but ignored for library crates. Ask the user which type this project is and adjust accordingly.
+
+### 5. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+```
+
+### 6. GitHub Actions workflow
+
+Create or update the CI workflow to include Rust linting, formatting, and security scanning jobs that only run when Rust files change. Use a separate workflow file (e.g., `.github/workflows/rust.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Rust
+on:
+  push:
+    paths: ['**/*.rs', 'Cargo.toml', 'Cargo.lock']
+  pull_request:
+    paths: ['**/*.rs', 'Cargo.toml', 'Cargo.lock']
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+```
+
+Don't duplicate if Rust lint jobs already exist. Look up latest action versions.
+
+### 7. Verify
+
+Run `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` to confirm. Fix any issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- If the project is a workspace, ensure clippy and fmt run across all workspace members.

--- a/home/dot_claude/commands/setup-shell.md
+++ b/home/dot_claude/commands/setup-shell.md
@@ -29,7 +29,11 @@ binary_next_line = true
 switch_case_indent = true
 ```
 
-### 3. Add pre-commit hooks
+### 3. .gitignore
+
+No shell-specific entries needed. Confirm `/setup-common` has already created a `.gitignore` with the standard entries (OS files, editor files, `.env`).
+
+### 4. Add pre-commit hooks
 
 Append these repos to the existing `.pre-commit-config.yaml`:
 
@@ -48,7 +52,32 @@ Append these repos to the existing `.pre-commit-config.yaml`:
 
 Look up the latest release tag for each repo and use those for the `rev:` values.
 
-### 4. Verify
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include a ShellCheck job that only runs when shell files change. Use a separate workflow file (e.g., `.github/workflows/shell.yml`) with path filters, or add a job to an existing workflow.
+
+```yaml
+name: Shell
+on:
+  push:
+    paths: ['**/*.sh', '**/*.bash']
+  pull_request:
+    paths: ['**/*.sh', '**/*.bash']
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.'
+```
+
+Don't duplicate if a ShellCheck job already exists. Look up the latest pinned commit SHA for `ludeeus/action-shellcheck`.
+
+### 6. Verify
 
 Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or formatting issues.
 

--- a/home/dot_claude/commands/setup-shell.md
+++ b/home/dot_claude/commands/setup-shell.md
@@ -1,0 +1,59 @@
+Set up shell script linting and formatting for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. ShellCheck
+
+Create `.shellcheckrc` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```
+# Default shell dialect
+shell=bash
+
+# Allow sourcing from paths that can't be followed
+external-sources=true
+
+# Disable specific rules if needed (keep this minimal)
+# disable=SC1091
+```
+
+### 2. shfmt
+
+shfmt reads its config from `.editorconfig` (indent_style and indent_size). Confirm `.editorconfig` exists and has sane defaults for shell files. If not, add:
+
+```ini
+[*.sh]
+indent_style = space
+indent_size = 2
+binary_next_line = true
+switch_case_indent = true
+```
+
+### 3. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: <latest tag>
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: <latest tag>
+    hooks:
+      - id: shfmt
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+### 4. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or formatting issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- If the project has `.bash` or other non-`.sh` extensions, add `types_or: [bash, sh]` to the shellcheck hook.

--- a/home/dot_claude/commands/setup-shell.md
+++ b/home/dot_claude/commands/setup-shell.md
@@ -6,7 +6,7 @@ Set up shell script linting and formatting for this project. Assumes `/setup-com
 
 Create `.shellcheckrc` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
 
-```
+```ini
 # Default shell dialect
 shell=bash
 

--- a/home/dot_claude/commands/setup-terraform.md
+++ b/home/dot_claude/commands/setup-terraform.md
@@ -1,0 +1,113 @@
+Set up Terraform linting, formatting, and security scanning for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. tflint
+
+Create `.tflint.hcl` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```hcl
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.31.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+```
+
+Adjust the cloud provider plugin based on what the project uses (AWS, Azure, GCP). Remove the AWS plugin if not applicable and add the relevant one. If unsure, ask the user.
+
+### 2. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan
+.terraform.lock.hcl
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+```
+
+### 3. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: <latest tag>
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint
+      - id: terraform_tfsec
+      - id: terraform_checkov
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include Terraform linting and security scanning jobs that only run when Terraform files change. Use a separate workflow file (e.g., `.github/workflows/terraform.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Terraform
+on:
+  push:
+    paths: ['**/*.tf', '**/*.tfvars']
+  pull_request:
+    paths: ['**/*.tf', '**/*.tfvars']
+
+jobs:
+  lint:
+    name: Terraform Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+
+  tflint:
+    name: TFLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: terraform-linters/setup-tflint@v4
+      - run: tflint --init
+      - run: tflint --recursive
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/tfsec-action@v1.0.3
+      - uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: .
+          framework: terraform
+```
+
+Don't duplicate if Terraform lint jobs already exist. Look up latest action versions.
+
+### 5. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or formatting issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- Ask the user which cloud provider(s) the project targets before configuring tflint plugins.

--- a/home/dot_claude/commands/setup-typescript.md
+++ b/home/dot_claude/commands/setup-typescript.md
@@ -1,0 +1,180 @@
+Set up TypeScript linting, formatting, type checking, and dependency auditing for this project. Assumes `/setup-common` has already been run (pre-commit framework is in place).
+
+## What to install and configure
+
+### 1. Prettier (formatting)
+
+Create `.prettierrc` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```json
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}
+```
+
+Create `.prettierignore` if it doesn't exist:
+
+```text
+node_modules/
+dist/
+build/
+coverage/
+```
+
+### 2. ESLint with typescript-eslint
+
+Create `eslint.config.ts` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```ts
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'warn',
+    },
+  },
+  {
+    ignores: ['node_modules/', 'dist/', 'build/', 'coverage/'],
+  },
+);
+```
+
+If type-checked rules are too slow or noisy for the project, use `tseslint.configs.recommended` instead of `recommendedTypeChecked`.
+
+### 3. TypeScript strict mode
+
+Review `tsconfig.json` and suggest enabling strict mode if not already set:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}
+```
+
+Do not overwrite existing `tsconfig.json`. Only suggest additions for missing strict options.
+
+### 4. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Node.js / TypeScript
+node_modules/
+dist/
+build/
+coverage/
+*.tgz
+.npm
+.eslintcache
+*.tsbuildinfo
+```
+
+### 5. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: <latest tag>
+    hooks:
+      - id: prettier
+        types_or: [typescript, tsx, javascript, jsx, json, css, markdown]
+
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: <latest tag>
+    hooks:
+      - id: eslint
+        types_or: [typescript, tsx]
+        additional_dependencies:
+          - eslint
+          - typescript
+          - typescript-eslint
+          - '@eslint/js'
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+### 6. GitHub Actions workflow
+
+Create or update the CI workflow to include TypeScript linting, type checking, and dependency auditing jobs that only run when TS files change. Use a separate workflow file (e.g., `.github/workflows/typescript.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: TypeScript
+on:
+  push:
+    paths: ['**/*.ts', '**/*.tsx', 'package.json', 'package-lock.json', 'tsconfig.json']
+  pull_request:
+    paths: ['**/*.ts', '**/*.tsx', 'package.json', 'package-lock.json', 'tsconfig.json']
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prettier --check .
+      - run: npx eslint .
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  audit:
+    name: npm Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+      - run: npm audit --audit-level=high
+```
+
+If the project doesn't have `.node-version`, use a fixed `node-version: '22'` (or whatever the project uses). Don't duplicate if TypeScript lint jobs already exist. Look up latest action versions.
+
+### 7. Verify
+
+Run `npx tsc --noEmit`, `npx prettier --check .`, and `npx eslint .` to confirm. Fix any issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `/setup-common` first.
+- Use ESLint flat config format. If the project has an existing `.eslintrc.*`, don't migrate unless asked.
+- If the project uses yarn or pnpm instead of npm, adjust commands and CI accordingly.
+- If the project is a monorepo, adjust `tsconfig.json` paths and ESLint config accordingly.

--- a/home/dot_git-templates/hooks/_lib/dispatch.sh
+++ b/home/dot_git-templates/hooks/_lib/dispatch.sh
@@ -1,0 +1,52 @@
+# dispatch.sh — shared library for git hook dispatchers
+# Sourced (not executed) by each hook script.
+# shellcheck shell=sh
+
+# ---------------------------------------------------------------------------
+# Detection helpers (file-based, fast)
+# ---------------------------------------------------------------------------
+
+has_precommit() {
+    [ -f "${GIT_WORK_TREE:-.}/.pre-commit-config.yaml" ]
+}
+
+has_beads() {
+    [ -d "${GIT_WORK_TREE:-.}/.beads" ]
+}
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+command_available() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+_warn() {
+    echo "git-hook-dispatch: $*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch helpers
+# ---------------------------------------------------------------------------
+
+run_precommit() {
+    _stage="$1"
+    has_precommit || return 0
+    if ! command_available pre-commit; then
+        _warn "pre-commit config found but 'pre-commit' is not installed"
+        return 0
+    fi
+    pre-commit run --hook-stage "$_stage" "$@"
+}
+
+run_beads() {
+    _hook="$1"
+    shift
+    has_beads || return 0
+    if ! command_available bd; then
+        _warn "beads config found but 'bd' is not installed"
+        return 0
+    fi
+    bd hook "$_hook" "$@"
+}

--- a/home/dot_git-templates/hooks/executable_post-checkout
+++ b/home/dot_git-templates/hooks/executable_post-checkout
@@ -1,0 +1,13 @@
+#!/bin/sh
+# No set -e — post-checkout failures should not block
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+# Only run on branch checkout ($3 = "1"), not file checkout
+[ "${3:-0}" = "1" ] || exit 0
+
+run_beads post-checkout "$@"

--- a/home/dot_git-templates/hooks/executable_post-merge
+++ b/home/dot_git-templates/hooks/executable_post-merge
@@ -1,0 +1,10 @@
+#!/bin/sh
+# No set -e — post-merge failures should not block
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+run_beads post-merge "$@"

--- a/home/dot_git-templates/hooks/executable_pre-commit
+++ b/home/dot_git-templates/hooks/executable_pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+# Beads first so its staged JSONL is included in pre-commit's lint pass
+run_beads pre-commit
+run_precommit pre-commit

--- a/home/dot_git-templates/hooks/executable_pre-push
+++ b/home/dot_git-templates/hooks/executable_pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+run_beads pre-push "$@"
+run_precommit pre-push

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -24,6 +24,7 @@
 
 [init]
 	defaultBranch = main
+	templateDir = ~/.git-templates
 
 [pull]
 	rebase = false


### PR DESCRIPTION
## Summary

- Add global git template hook dispatcher system for consistent pre-commit/post-merge/post-checkout/pre-push hooks across all repos
- Add Claude Code configuration directory (`~/.claude/`) with CLAUDE.md policy and README documenting the layered enforcement model (CI > pre-commit > Claude hooks)
- Add 14 composable `/setup-*` slash commands: common, shell, markdown, docker, terraform, go, python, dotnet, rust, java, ruby, php, node, typescript
- Each command configures formatting, linting, security scanning, CI workflows, and pre-commit hooks for its language

## Test plan

- [ ] Run `chezmoi apply --dry-run` to verify dotfile targets are correct
- [ ] Verify `.chezmoiignore` excludes `README.md` from deployment
- [ ] Test `/setup-common` on a fresh repo to confirm pre-commit framework setup
- [ ] Test a language-specific command (e.g., `/setup-python`) to confirm it layers correctly on top of common

🤖 Generated with [Claude Code](https://claude.com/claude-code)