### PR TITLE
feat(claude): add Dependabot auto-merge and ecosystem config to setup skills

### DIFF
--- a/home/dot_claude/README.md
+++ b/home/dot_claude/README.md
@@ -20,7 +20,7 @@ Checks are enforced at three layers, from most authoritative to most immediate. 
 
 ### Layer 1: CI (Always Enforced)
 
-CI runs on every push/PR. This is the **source of truth** — nothing merges without passing. Each `/setup-*` slash command includes a CI workflow snippet for the relevant language.
+CI runs on every push/PR. This is the **source of truth** — nothing merges without passing. Each `/setup-*` slash command includes a CI workflow snippet for the relevant language. The `/setup-common` command also installs a Dependabot auto-merge workflow that approves and squash-merges Dependabot PRs once CI passes.
 
 ### Layer 2: Git Pre-commit Hooks
 
@@ -45,22 +45,22 @@ Claude Code hooks provide **immediate feedback during editing**. Only use these 
 
 Each `/setup-*` slash command configures the tools listed below. All commands are **additive and composable** — run `/setup-common` first for the foundation, then stack any combination.
 
-| Language | Formatting | Linting | Type Checking | Security | Deps Audit |
-| -------- | ---------- | ------- | ------------- | -------- | ---------- |
-| **Common** | — | — | — | gitleaks | — |
-| **Markdown** | prettier | markdownlint-cli2 | — | — | — |
-| **Shell** | shfmt | shellcheck | — | — | — |
-| **Docker** | — | hadolint | — | trivy | — |
-| **Terraform** | terraform fmt | tflint, terraform validate | — | tfsec, checkov | — |
-| **Go** | gofmt / goimports | golangci-lint | — | — | govulncheck |
-| **Python** | ruff | ruff | mypy / pyright | bandit | — |
-| **.NET / C#** | dotnet format | Roslyn analysers | — | SecurityCodeScan | dotnet outdated |
-| **Rust** | rustfmt | clippy | — | — | cargo-audit, cargo-deny |
-| **Java** | google-java-format / spotless | checkstyle, SpotBugs, PMD | — | — | OWASP dependency-check |
-| **Ruby** | rubocop | rubocop | — | brakeman | bundler-audit |
-| **PHP** | PHP-CS-Fixer / PHP_CodeSniffer | PHPStan / Psalm | — | — | composer audit |
-| **Node.js** | prettier | eslint | — | — | npm audit |
-| **TypeScript** | prettier | eslint + typescript-eslint | tsc --noEmit | — | npm audit |
+| Language | Formatting | Linting | Type Checking | Security | Deps Audit | Dependabot |
+| -------- | ---------- | ------- | ------------- | -------- | ---------- | ---------- |
+| **Common** | — | — | — | gitleaks | — | github-actions |
+| **Markdown** | prettier | markdownlint-cli2 | — | — | — | — |
+| **Shell** | shfmt | shellcheck | — | — | — | — |
+| **Docker** | — | hadolint | — | trivy | — | docker |
+| **Terraform** | terraform fmt | tflint, terraform validate | — | tfsec, checkov | — | terraform |
+| **Go** | gofmt / goimports | golangci-lint | — | — | govulncheck | gomod |
+| **Python** | ruff | ruff | mypy / pyright | bandit | — | pip |
+| **.NET / C#** | dotnet format | Roslyn analysers | — | SecurityCodeScan | dotnet outdated | nuget |
+| **Rust** | rustfmt | clippy | — | — | cargo-audit, cargo-deny | cargo |
+| **Java** | google-java-format / spotless | checkstyle, SpotBugs, PMD | — | — | OWASP dependency-check | maven |
+| **Ruby** | rubocop | rubocop | — | brakeman | bundler-audit | bundler |
+| **PHP** | PHP-CS-Fixer / PHP_CodeSniffer | PHPStan / Psalm | — | — | composer audit | composer |
+| **Node.js** | prettier | eslint | — | — | npm audit | npm |
+| **TypeScript** | prettier | eslint + typescript-eslint | tsc --noEmit | — | npm audit | npm |
 
 ### Which Layer Runs What
 
@@ -103,6 +103,7 @@ Each `/setup-*` command contains:
 2. Configuration file contents
 3. Pre-commit hook registration
 4. CI workflow snippet
+5. Dependabot ecosystem configuration
 
 **New project setup:**
 

--- a/home/dot_claude/commands/setup-docker.md
+++ b/home/dot_claude/commands/setup-docker.md
@@ -71,7 +71,26 @@ Don't duplicate if Docker lint jobs already exist. Look up latest action version
 
 If the project builds container images, suggest also adding an image scan step that runs `trivy image` after the build.
 
-### 5. Verify
+### 5. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `docker` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+    open-pull-requests-limit: 5
+```
+
+### 6. Verify
 
 Run `pre-commit run --all-files` to confirm hooks work. Fix any lint issues.
 

--- a/home/dot_claude/commands/setup-dotnet.md
+++ b/home/dot_claude/commands/setup-dotnet.md
@@ -129,7 +129,26 @@ jobs:
 
 Adjust `dotnet-version` to match the project. Don't duplicate if .NET build jobs already exist. Look up latest action versions.
 
-### 6. Verify
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `nuget` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "dotnet"
+    open-pull-requests-limit: 5
+```
+
+### 7. Verify
 
 Run `dotnet build` to confirm analysers are active and no warnings are emitted. Run `dotnet format --verify-no-changes` to confirm formatting.
 

--- a/home/dot_claude/commands/setup-go.md
+++ b/home/dot_claude/commands/setup-go.md
@@ -117,7 +117,26 @@ Don't duplicate if Go lint jobs already exist. Look up latest action versions.
 
 Check if `govulncheck` is installed (`go install golang.org/x/vuln/cmd/govulncheck@latest`). If not, tell the user to install it. It's run manually or in CI (above), not as a pre-commit hook (too slow).
 
-### 6. Verify
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `gomod` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+    open-pull-requests-limit: 5
+```
+
+### 7. Verify
 
 Run `pre-commit run --all-files` to confirm hooks work. Fix any lint issues.
 

--- a/home/dot_claude/commands/setup-java.md
+++ b/home/dot_claude/commands/setup-java.md
@@ -154,7 +154,28 @@ jobs:
 
 Adjust for Maven if the project uses `pom.xml` instead of Gradle. Don't duplicate if Java lint jobs already exist. Look up latest action versions.
 
-### 7. Verify
+### 7. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `maven` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "java"
+    open-pull-requests-limit: 5
+```
+
+If the project uses Gradle instead of Maven, use `gradle` as the `package-ecosystem` value.
+
+### 8. Verify
 
 Run `./gradlew spotlessCheck` (or `mvn spotless:check`) to confirm formatting. Fix any issues with `./gradlew spotlessApply`.
 

--- a/home/dot_claude/commands/setup-node.md
+++ b/home/dot_claude/commands/setup-node.md
@@ -126,7 +126,26 @@ jobs:
 
 If the project doesn't have `.node-version`, use a fixed `node-version: '22'` (or whatever the project uses). Don't duplicate if Node.js lint jobs already exist. Look up latest action versions.
 
-### 6. Verify
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `npm` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 5
+```
+
+### 7. Verify
 
 Run `npx prettier --check .` and `npx eslint .` to confirm. Fix formatting issues with `npx prettier --write .`.
 

--- a/home/dot_claude/commands/setup-php.md
+++ b/home/dot_claude/commands/setup-php.md
@@ -124,7 +124,26 @@ jobs:
 
 Adjust `php-version` to match the project. Don't duplicate if PHP lint jobs already exist. Look up latest action versions.
 
-### 6. Verify
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `composer` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "php"
+    open-pull-requests-limit: 5
+```
+
+### 7. Verify
 
 Run `vendor/bin/php-cs-fixer fix --dry-run --diff` and `vendor/bin/phpstan analyse` to confirm. Fix any issues.
 

--- a/home/dot_claude/commands/setup-python.md
+++ b/home/dot_claude/commands/setup-python.md
@@ -151,7 +151,28 @@ exclude_dirs = ["tests", ".venv", "venv"]
 skips = []
 ```
 
-### 7. Verify
+### 7. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `pip` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+```
+
+If `pyproject.toml` is in a subdirectory rather than the repo root, adjust `directory` accordingly.
+
+### 8. Verify
 
 Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or type issues.
 

--- a/home/dot_claude/commands/setup-ruby.md
+++ b/home/dot_claude/commands/setup-ruby.md
@@ -111,7 +111,26 @@ Don't duplicate if Ruby lint jobs already exist. Look up latest action versions.
 
 Brakeman is only relevant for Rails applications. If the project is not a Rails app, skip the brakeman job.
 
-### 5. Verify
+### 5. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `bundler` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "ruby"
+    open-pull-requests-limit: 5
+```
+
+### 6. Verify
 
 Run `bundle exec rubocop` to confirm. Fix any issues with `bundle exec rubocop --auto-correct`.
 

--- a/home/dot_claude/commands/setup-rust.md
+++ b/home/dot_claude/commands/setup-rust.md
@@ -149,7 +149,26 @@ jobs:
 
 Don't duplicate if Rust lint jobs already exist. Look up latest action versions.
 
-### 7. Verify
+### 7. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `cargo` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+    open-pull-requests-limit: 5
+```
+
+### 8. Verify
 
 Run `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` to confirm. Fix any issues.
 

--- a/home/dot_claude/commands/setup-terraform.md
+++ b/home/dot_claude/commands/setup-terraform.md
@@ -102,7 +102,26 @@ jobs:
 
 Don't duplicate if Terraform lint jobs already exist. Look up latest action versions.
 
-### 5. Verify
+### 5. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `terraform` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "terraform"
+    open-pull-requests-limit: 5
+```
+
+### 6. Verify
 
 Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or formatting issues.
 

--- a/home/dot_claude/commands/setup-typescript.md
+++ b/home/dot_claude/commands/setup-typescript.md
@@ -167,7 +167,26 @@ jobs:
 
 If the project doesn't have `.node-version`, use a fixed `node-version: '22'` (or whatever the project uses). Don't duplicate if TypeScript lint jobs already exist. Look up latest action versions.
 
-### 7. Verify
+### 7. Dependabot ecosystem
+
+If the `npm` ecosystem is already configured in `.github/dependabot.yml` (e.g. from `/setup-node`), skip this step. Otherwise, read `.github/dependabot.yml` and add the `npm` ecosystem entry:
+
+```yaml
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 5
+```
+
+### 8. Verify
 
 Run `npx tsc --noEmit`, `npx prettier --check .`, and `npx eslint .` to confirm. Fix any issues.
 


### PR DESCRIPTION
## Summary

- Add Dependabot auto-merge workflow to `/setup-common` — approves and squash-merges Dependabot PRs once CI passes
- Add Dependabot ecosystem configuration section to 11 language-specific `/setup-*` skills (pip, npm, gomod, cargo, bundler, composer, nuget, maven, docker, terraform)
- Update README tooling matrix with a Dependabot column showing each language's ecosystem

## Test plan

- [ ] Verify markdownlint passes on all modified files (`npx markdownlint-cli2 "home/dot_claude/**/*.md"`)
- [ ] Confirm each setup skill has the Dependabot section placed before the Verify section with correct numbering
- [ ] Check that `setup-typescript.md` includes the idempotency note for npm ecosystem
- [ ] Check that `setup-java.md` includes the Gradle alternative note
- [ ] Verify the auto-merge workflow YAML in `setup-common.md` is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)