### PR TITLE
feat(claude): add Terraform MCP server to setup script

### DIFF
--- a/home/run_onchange_setup-claude.sh
+++ b/home/run_onchange_setup-claude.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+# Skip if Claude Code CLI is not installed
+if ! command -v claude >/dev/null 2>&1; then
+    echo "Claude Code CLI not found, skipping MCP setup..."
+    exit 0
+fi
+
+# Source secrets if available
+SECRETS_FILE="$HOME/.secrets"
+if [ -f "$SECRETS_FILE" ]; then
+    # shellcheck source=/dev/null
+    . "$SECRETS_FILE"
+fi
+
+echo "Configuring Claude Code MCP servers..."
+
+# Google Developer Knowledge — requires API key from ~/.secrets
+if [ -n "${GOOGLE_DEV_KNOWLEDGE_API_KEY:-}" ]; then
+    claude mcp add --transport http --scope user \
+        google-dev-knowledge \
+        https://developerknowledge.googleapis.com/mcp \
+        --header "X-Goog-Api-Key: ${GOOGLE_DEV_KNOWLEDGE_API_KEY}"
+    echo "  Added google-dev-knowledge"
+else
+    echo "  Skipped google-dev-knowledge (no API key in ~/.secrets)"
+fi
+
+# Terraform — provider docs, module search (requires Docker)
+if command -v docker >/dev/null 2>&1; then
+    claude mcp add --transport stdio --scope user \
+        terraform -- \
+        docker run -i --rm hashicorp/terraform-mcp-server
+    echo "  Added terraform"
+else
+    echo "  Skipped terraform (Docker not installed)"
+fi
+
+echo "Claude Code MCP setup complete."


### PR DESCRIPTION
## Summary
- Adds HashiCorp Terraform MCP server (provider docs, module search) to the `run_onchange_setup-claude.sh` script
- Uses Docker transport with `--scope user` for global availability
- Guards on Docker being installed, skips gracefully if not

🤖 Generated with [Claude Code](https://claude.com/claude-code)