### PR TITLE
fix: gitignore chezmoi binary and remove from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 
 # Ignore temporary files
 temp/
+
+# Ignore downloaded binaries
+bin/


### PR DESCRIPTION
## Summary
- Added `bin/` to `.gitignore` to prevent downloaded binaries from being tracked
- Removed `bin/chezmoi` from git tracking (it was inadvertently committed)

## Test plan
- [ ] Verify `bin/chezmoi` no longer appears in `git ls-files`
- [ ] Verify `chezmoi init` still works (binary downloads to `bin/` but isn't tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)