### PR TITLE
feat: add rectangle cask to work machine type

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -74,6 +74,7 @@
             casks = [
                 "font-jetbrains-mono-nerd-font",
                 "ghostty",
+                "rectangle",
             ]
 {{- else }}
             taps = []


### PR DESCRIPTION
## Summary
- Adds `rectangle` to the Homebrew casks list for the `work` machine type
- Rectangle is already included in the `personal` profile; this promotes it to `work` as well since it's a core window management tool

## Test plan
- [ ] Verify CI passes (chezmoi apply on macOS runner)
- [ ] Confirm `chezmoi execute-template` renders Rectangle in the work Brewfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)