### PR TITLE
feat(zsh): wire up fzf, nvm, jenv, and EDITOR in .zshrc

### DIFF
--- a/home/dot_zshrc
+++ b/home/dot_zshrc
@@ -18,7 +18,6 @@ export PATH="/opt/homebrew/bin:$PATH"
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME=""
-echo "$ZSH_THEME"
 
 # Starship prompt, only if the VSCODE_COPILOT_CHAT_TERMINAL is not set to 1
 if [ -z "$VSCODE_COPILOT_CHAT_TERMINAL" ] || [ "$VSCODE_COPILOT_CHAT_TERMINAL" != "1" ]; then
@@ -78,7 +77,6 @@ plugins=(
   copypath
   copyfile
 )
-echo "plugins: ${plugins[*]}"
 
 # shellcheck source=/dev/null
 source "$ZSH/oh-my-zsh.sh"
@@ -90,15 +88,28 @@ source "$ZSH/oh-my-zsh.sh"
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8
 
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
+# Preferred editor
+export EDITOR="code --wait"
 
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
+# --- Tool integrations ---
+
+# fzf key bindings and fuzzy completion
+if command -v fzf >/dev/null 2>&1; then
+  eval "$(fzf --zsh)"
+fi
+
+# nvm (Node Version Manager)
+export NVM_DIR="$HOME/.nvm"
+# shellcheck disable=SC1091
+[ -s "$(brew --prefix nvm)/nvm.sh" ] && \. "$(brew --prefix nvm)/nvm.sh"
+# shellcheck disable=SC1091
+[ -s "$(brew --prefix nvm)/etc/bash_completion.d/nvm" ] && \. "$(brew --prefix nvm)/etc/bash_completion.d/nvm"
+
+# jenv (Java Environment Manager)
+if command -v jenv >/dev/null 2>&1; then
+  export PATH="$HOME/.jenv/bin:$PATH"
+  eval "$(jenv init -)"
+fi
 
 # Load custom aliases and functions
 # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary

- Remove two debug `echo` statements that printed noise on every shell startup
- Set `EDITOR` to `code --wait` for VS Code integration
- Add guarded initialization for **fzf** (fuzzy finder keybindings + completion), **nvm** (Node Version Manager), and **jenv** (Java Environment Manager) so Homebrew-installed tools actually work

All tool inits are guarded by `command -v` or file-existence checks, so they're safe on machines where the tools aren't installed (e.g., minimal machine type). No impact on CI runners.

## Test plan

- [ ] ShellCheck passes (`shellcheck home/dot_zshrc`)
- [ ] Open new terminal — no debug output on startup
- [ ] `echo $EDITOR` returns `code --wait`
- [ ] fzf keybindings work (Ctrl+R for history, Ctrl+T for file search)
- [ ] `nvm --version` works
- [ ] `jenv --version` works
- [ ] CI passes (tools aren't installed on runners, guards skip init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)