### PR TITLE
chore(beads): update hooks and gitignore for v0.57 Dolt migration

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -18,8 +18,6 @@ redirect
 # Sync state (local-only, per-machine)
 # These files are machine-specific and should not be shared across clones
 .sync.lock
-.jsonl.lock
-sync_base.jsonl
 export-state/
 
 # Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
@@ -27,6 +25,11 @@ ephemeral.sqlite3
 ephemeral.sqlite3-journal
 ephemeral.sqlite3-wal
 ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
 
 # Legacy files (from pre-Dolt versions)
 *.db
@@ -40,15 +43,7 @@ daemon.lock
 daemon.log
 daemon-*.log.gz
 daemon.pid
-beads.base.jsonl
-beads.base.meta.json
-beads.left.jsonl
-beads.left.meta.json
-beads.right.jsonl
-beads.right.meta.json
-
-# NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.
-# They would override fork protection in .git/info/exclude, allowing
-# contributors to accidentally commit upstream issue databases.
-# The JSONL files (issues.jsonl, interactions.jsonl) and config files
-# are tracked by git by default since no pattern above ignores them.
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,17 +1,9 @@
 #!/usr/bin/env sh
-# bd-shim v1
-# bd-hooks-version: 0.56.1
-#
-# bd (beads) post-checkout hook - thin shim
-#
-# This shim delegates to 'bd hooks run post-checkout' which contains
-# the actual hook logic. This pattern ensures hook behavior is always
-# in sync with the installed bd version - no manual updates needed.
-
-# Check if bd is available
-if ! command -v bd >/dev/null 2>&1; then
-    # Silently skip - post-checkout is called frequently
-    exit 0
+# --- BEGIN BEADS INTEGRATION v0.57.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  bd hooks run post-checkout "$@"
+  _bd_exit=$?; if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-
-exec bd hooks run post-checkout "$@"
+# --- END BEADS INTEGRATION ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,19 +1,9 @@
 #!/usr/bin/env sh
-# bd-shim v1
-# bd-hooks-version: 0.56.1
-#
-# bd (beads) post-merge hook - thin shim
-#
-# This shim delegates to 'bd hooks run post-merge' which contains
-# the actual hook logic. This pattern ensures hook behavior is always
-# in sync with the installed bd version - no manual updates needed.
-
-# Check if bd is available
-if ! command -v bd >/dev/null 2>&1; then
-    echo "Warning: bd command not found in PATH, skipping post-merge hook" >&2
-    echo "  Install bd: brew install beads" >&2
-    echo "  Or add bd to your PATH" >&2
-    exit 0
+# --- BEGIN BEADS INTEGRATION v0.57.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  bd hooks run post-merge "$@"
+  _bd_exit=$?; if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-
-exec bd hooks run post-merge "$@"
+# --- END BEADS INTEGRATION ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,19 +1,9 @@
 #!/usr/bin/env sh
-# bd-shim v2
-# bd-hooks-version: 0.56.1
-#
-# bd (beads) pre-commit hook — thin shim
-#
-# Delegates to 'bd hooks run pre-commit' which contains the actual hook
-# logic. This pattern ensures hook behavior is always in sync with the
-# installed bd version — no manual updates needed.
-
-# Check if bd is available
-if ! command -v bd >/dev/null 2>&1; then
-    echo "Warning: bd command not found in PATH, skipping pre-commit hook" >&2
-    echo "  Install bd: brew install beads" >&2
-    echo "  Or add bd to your PATH" >&2
-    exit 0
+# --- BEGIN BEADS INTEGRATION v0.57.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  bd hooks run pre-commit "$@"
+  _bd_exit=$?; if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-
-exec bd hooks run pre-commit "$@"
+# --- END BEADS INTEGRATION ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,19 +1,9 @@
 #!/usr/bin/env sh
-# bd-shim v1
-# bd-hooks-version: 0.56.1
-#
-# bd (beads) pre-push hook - thin shim
-#
-# This shim delegates to 'bd hooks run pre-push' which contains
-# the actual hook logic. This pattern ensures hook behavior is always
-# in sync with the installed bd version - no manual updates needed.
-
-# Check if bd is available
-if ! command -v bd >/dev/null 2>&1; then
-    echo "Warning: bd command not found in PATH, skipping pre-push hook" >&2
-    echo "  Install bd: brew install beads" >&2
-    echo "  Or add bd to your PATH" >&2
-    exit 0
+# --- BEGIN BEADS INTEGRATION v0.57.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  bd hooks run pre-push "$@"
+  _bd_exit=$?; if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-
-exec bd hooks run pre-push "$@"
+# --- END BEADS INTEGRATION ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,24 +1,9 @@
 #!/usr/bin/env sh
-# bd-shim v1
-# bd-hooks-version: 0.48.0
-#
-# bd (beads) prepare-commit-msg hook - thin shim
-#
-# This shim delegates to 'bd hooks run prepare-commit-msg' which contains
-# the actual hook logic. This pattern ensures hook behavior is always
-# in sync with the installed bd version - no manual updates needed.
-#
-# Arguments:
-#   $1 = path to the commit message file
-#   $2 = source of commit message (message, template, merge, squash, commit)
-#   $3 = commit SHA-1 (if -c, -C, or --amend)
-
-# Check if bd is available
-if ! command -v bd >/dev/null 2>&1; then
-    echo "Warning: bd command not found in PATH, skipping prepare-commit-msg hook" >&2
-    echo "  Install bd: brew install beads" >&2
-    echo "  Or add bd to your PATH" >&2
-    exit 0
+# --- BEGIN BEADS INTEGRATION v0.57.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  bd hooks run prepare-commit-msg "$@"
+  _bd_exit=$?; if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-
-exec bd hooks run prepare-commit-msg "$@"
+# --- END BEADS INTEGRATION ---

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ temp/
 
 # Ignore downloaded binaries
 bin/
+
+# Dolt database files (added by bd init)
+.dolt/
+*.db


### PR DESCRIPTION
## Summary
- Update beads git hooks from legacy shim format (v0.56.1) to new section marker format (v0.57.0)
- Update `.beads/.gitignore` and `.gitignore` for Dolt backend (removes JSONL references, adds Dolt server/db ignores)
- Remove stale `actionlint` binary (5.7MB ELF) that was accidentally tracked in git

## Context
These are uncommitted changes left over from the beads v0.56 -> v0.57 Dolt migration. The `bd doctor` "uncommitted changes" warning will clear once merged.

Note: `bd doctor` still reports hooks as "incompatible with Dolt backend" — this is a [beads bug](https://github.com/pmgledhill102/dotfiles/pull/new/chore/beads-057-migration) where `doctor` parses the legacy `bd-hooks-version:` marker but `hooks install` now writes the new `BEGIN BEADS INTEGRATION v0.57.0` section marker format.

## Test plan
- [ ] CI passes (shellcheck, markdownlint, actionlint, chezmoi apply)
- [ ] `bd doctor` no longer warns about uncommitted changes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)