### PR TITLE
fix(ci): skip pinned winget packages in CI

### DIFF
--- a/home/dot_config/winget-packages.json.tmpl
+++ b/home/dot_config/winget-packages.json.tmpl
@@ -4,7 +4,10 @@
   "Sources" : [
     {
       "Packages" : [
-{{- $allPackages := concat .packages.winget.packages .packages.winget.packages_pinned }}
+{{- $allPackages := .packages.winget.packages }}
+{{- if ne (env "CI") "true" }}
+{{- $allPackages = concat $allPackages .packages.winget.packages_pinned }}
+{{- end }}
 {{- range $index, $package := $allPackages }}
         {
           "PackageIdentifier" : "{{ $package }}"

--- a/home/run_once_install-packages-windows.ps1.tmpl
+++ b/home/run_once_install-packages-windows.ps1.tmpl
@@ -93,6 +93,7 @@ Write-Host "  Success: $successCount" -ForegroundColor Green
 Write-Host "  Failed:  $failureCount" -ForegroundColor Red
 Write-Host "  Skipped: $skippedCount" -ForegroundColor Yellow
 
+{{- if ne (env "CI") "true" }}
 Write-Host ""
 Write-Host "=================================="
 Write-Host "Pinning Packages (exclude from winget upgrade)"
@@ -117,6 +118,10 @@ foreach ($package in $pinnedPackages) {
         Write-Host "  Failed to pin (may already be pinned)" -ForegroundColor Yellow
     }
 }
+{{- else }}
+Write-Host ""
+Write-Host "CI detected — skipping pinned package installation and pinning"
+{{- end }}
 
 Write-Host ""
 Write-Host "Refreshing environment PATH..."


### PR DESCRIPTION
## Summary
- Exclude `packages_pinned` (GOG.Galaxy, Steam, Epic, Ubisoft, etc.) from the winget install JSON when `CI=true`
- Wrap the pinning section in the install script with the same CI check
- These game launchers have complex installers that hang on GitHub Actions runners

## Test plan
- [ ] Windows CI job completes without hanging
- [ ] Local `chezmoi apply` on Windows still installs and pins all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)