### PR TITLE
ci: skip install tests on PRs, add schedule + dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: '0 6 * * 5'   # Weekly Friday 06:00 UTC
+  workflow_dispatch: {}    # Manual trigger from Actions tab
 
 permissions:
   contents: read
@@ -49,7 +52,7 @@ jobs:
 
   test-install:
     name: Test Install on ${{ matrix.os }}
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request'
     needs: [shellcheck, markdown-lint, actionlint]
     runs-on: ${{ matrix.os }}
     strategy:

--- a/specs/REQUIREMENTS.md
+++ b/specs/REQUIREMENTS.md
@@ -9,6 +9,9 @@ spec, research, and plan documents (Oct 2025).
 - **Idempotent**: all install scripts safe to re-run without errors or duplicates
 - **Performance**: shell startup under 1 second on modern hardware (NFR-PERF-001)
 - **CI budget**: test matrix completes within 10 minutes per platform
+  - PRs: lint only (shellcheck, markdownlint, actionlint)
+  - Merge to main: full install test on all platforms
+  - Weekly schedule + manual dispatch: catch upstream breakage
 
 ## Principles
 


### PR DESCRIPTION
## Summary

- **PRs**: Run lint jobs only (shellcheck, markdownlint, actionlint) — ~2 min feedback
- **Push to main**: Full install tests on all 3 platforms — safety net after merge
- **Weekly schedule** (Friday 06:00 UTC): Catch upstream breakage (package renames, formula deprecations)
- **Manual dispatch**: Escape hatch to force full tests before merging when needed

## Motivation

The `test-install` job takes ~30 min on Windows due to sequential winget installs, violating the 10-min CI budget. For a single-developer repo, most PRs don't need full install validation — lint catches the majority of issues, and main always runs the full suite.

## Test plan

- [ ] Verify this PR only runs lint jobs (no `test-install`)
- [ ] After merge, verify push-to-main triggers `test-install` on all 3 platforms
- [ ] Use "Run workflow" button in Actions tab to verify manual dispatch
- [ ] After next Friday 06:00 UTC, confirm scheduled run fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)