### PR TITLE
docs: trim AGENTS.md, update CI references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,129 +1,26 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
-
-## Quick Reference
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get
+started.
 
 ```bash
 bd ready              # Find available work
 bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
+bd update <id> --status=in_progress  # Claim work
 bd close <id>         # Complete work
-bd sync               # Sync with git
 ```
 
-## Landing the Plane (Session Completion)
+## Session Completion
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+Work is NOT complete until `git push` succeeds.
 
-**MANDATORY WORKFLOW:**
+1. Close finished issues (`bd close <id>`)
+2. Create issues for remaining work (`bd create --title="..." --description="..."`)
+3. Commit and push code changes
+4. Verify `git status` shows "up to date with origin"
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+## Rules
 
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
-
-<!-- BEGIN BEADS INTEGRATION -->
-## Issue Tracking with bd (beads)
-
-**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
-
-### Why bd?
-
-- Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Auto-syncs to JSONL for version control
-- Agent-optimized: JSON output, ready work detection, discovered-from links
-- Prevents duplicate tracking systems and confusion
-
-### Quick Start
-
-**Check for ready work:**
-
-```bash
-bd ready --json
-```
-
-**Create new issues:**
-
-```bash
-bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
-```
-
-**Claim and update:**
-
-```bash
-bd update bd-42 --status in_progress --json
-bd update bd-42 --priority 1 --json
-```
-
-**Complete work:**
-
-```bash
-bd close bd-42 --reason "Completed" --json
-```
-
-### Issue Types
-
-- `bug` - Something broken
-- `feature` - New functionality
-- `task` - Work item (tests, docs, refactoring)
-- `epic` - Large feature with subtasks
-- `chore` - Maintenance (dependencies, tooling)
-
-### Priorities
-
-- `0` - Critical (security, data loss, broken builds)
-- `1` - High (major features, important bugs)
-- `2` - Medium (default, nice-to-have)
-- `3` - Low (polish, optimization)
-- `4` - Backlog (future ideas)
-
-### Workflow for AI Agents
-
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task**: `bd update <id> --status in_progress`
-3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
-
-### Auto-Sync
-
-bd automatically syncs with git:
-
-- Exports to `.beads/issues.jsonl` after changes (5s debounce)
-- Imports from JSONL when newer (e.g., after `git pull`)
-- No manual export/import needed!
-
-### Important Rules
-
-- ✅ Use bd for ALL task tracking
-- ✅ Always use `--json` flag for programmatic use
-- ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
-- ❌ Do NOT create markdown TODO lists
-- ❌ Do NOT use external issue trackers
-- ❌ Do NOT duplicate tracking systems
-
-For more details, see README.md and docs/QUICKSTART.md.
-
-<!-- END BEADS INTEGRATION -->
+- Use bd for ALL task tracking — no markdown TODOs or external trackers
+- Always push before ending a session
+- Link discovered work: `bd dep add <new> discovered-from:<parent>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,13 +60,11 @@ fix(install): correct Ubuntu package installation
 
 ## CI
 
-CI runs on every push/PR to `main` (`.github/workflows/ci.yml`):
+CI is defined in `.github/workflows/ci.yml`:
 
-- **ShellCheck** on `scripts/` and `home/`
-- **markdownlint-cli2** on all `*.md` files
-- **actionlint** on GitHub Actions workflows
-- **Test Install** matrix (Ubuntu, macOS, Windows): `chezmoi init --apply`
-  followed by validation scripts
+- **PRs**: lint only — ShellCheck, markdownlint-cli2, actionlint (~2 min)
+- **Push to main**: lint + full install test matrix (Ubuntu, macOS, Windows)
+- **Weekly / manual dispatch**: full install tests to catch upstream breakage
 
 Pre-commit hooks run markdownlint-cli2 locally.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,7 +15,9 @@ The dotfiles repository includes comprehensive automated testing to ensure relia
 
 ### GitHub Actions Workflow
 
-All changes are automatically tested via GitHub Actions. The workflow includes:
+CI is defined in `.github/workflows/ci.yml`. PRs run lint jobs only; full
+install tests run on push to main, weekly, and via manual dispatch. The
+workflow includes:
 
 1. **Linting and Static Analysis**
    - ShellCheck for shell scripts


### PR DESCRIPTION
## Summary

- **AGENTS.md**: Trimmed from 129 → 25 lines. Removed bd documentation that's redundant with the beads system prompt injected into every agent session. Fixed broken `docs/QUICKSTART.md` link.
- **CONTRIBUTING.md**: Updated CI section to reflect the tiered strategy from #63 (PRs = lint only, push to main = full install tests).
- **docs/TESTING.md**: Updated workflow description to match tiered CI.

Closes the docs review task (dotfiles-auy).

## Test plan

- [ ] Verify lint passes on this PR
- [ ] Review that AGENTS.md still contains everything an agent needs to get started (the rest comes from the beads system prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)