### PR TITLE
feat(zsh): add z and extract plugins

### DIFF
--- a/home/dot_zshrc
+++ b/home/dot_zshrc
@@ -73,9 +73,11 @@ plugins=(
   zsh-syntax-highlighting
   colored-man-pages
   command-not-found
+  extract
   history
   copypath
   copyfile
+  z
 )
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary

- **z**: Jump to frequently-used directories by partial name (e.g. `z dot` → `/Users/paul/dev/dotfiles`)
- **extract**: Universal `extract <file>` command for any archive format (.tar.gz, .zip, .7z, etc.)

Both are Oh My Zsh built-ins — no install step needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)