### PR TITLE
fix(zsh): use upgrade.sh for Oh My Zsh updates

### DIFF
--- a/home/dot_config/zsh/aliases.zsh
+++ b/home/dot_config/zsh/aliases.zsh
@@ -16,7 +16,7 @@ dotup() {
 
   if [ -d "$ZSH" ]; then
     echo "\n==> Updating Oh My Zsh..."
-    omz update --unattended
+    "$ZSH/tools/upgrade.sh"
   fi
 
   local plugin_dir="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins"


### PR DESCRIPTION
## Summary

- Replace `omz update --unattended` with `$ZSH/tools/upgrade.sh` in `dotup`
- OMZ removed the `--unattended` flag; `upgrade.sh` is the non-interactive replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)