### PR TITLE
revert(chezmoi): re-enable macOS defaults script

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -8,10 +8,6 @@
 .claude/README.md
 .claude/settings.json.md
 
-# macOS defaults — disabled until reviewed and tested
-run_once_macos_defaults.sh
-macos_defaults.sh
-
 # Only apply PowerShell scripts on Windows
 {{- if ne .chezmoi.os "windows" }}
 run_once_install-packages-windows.ps1


### PR DESCRIPTION
## Summary
- Removes the unconditional ignore of `run_once_macos_defaults.sh` added in #71
- Verified current machine settings match the script on 15/16 settings (only Finder status bar differs)
- Safe to apply on new machines

## Test plan
- [ ] `chezmoi managed` lists `run_once_macos_defaults.sh`
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)