### PR TITLE
fix(winget): pin Discord to prevent upgrade conflicts

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -189,7 +189,6 @@
                 "CrystalDewWorld.CrystalDiskMark",
                 "dandavison.delta",
                 "DEVCOM.JetBrainsMonoNerdFont",
-                "Discord.Discord",
                 "FiloSottile.age",
                 "Git.Git",
                 "GitHub.cli",
@@ -233,6 +232,7 @@
             # Packages installed but pinned (excluded from winget upgrade).
             # These have built-in auto-updaters that conflict with winget.
             packages_pinned = [
+                "Discord.Discord",
                 "ElectronicArts.EADesktop",
                 "EpicGames.EpicGamesLauncher",
                 "GOG.Galaxy",


### PR DESCRIPTION
## Summary

- Move `Discord.Discord` from `packages` to `packages_pinned` in winget config
- Discord has a built-in auto-updater that conflicts with `winget upgrade`, same as Steam, Epic, GOG, etc.

Closes #70

## Test plan

- [ ] CI passes
- [ ] `Discord.Discord` appears in `packages_pinned` not `packages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)