### PR TITLE
fix(brew): resolve Homebrew PATH in brewfile script

### DIFF
--- a/home/run_onchange_install-brewfile.sh.tmpl
+++ b/home/run_onchange_install-brewfile.sh.tmpl
@@ -8,10 +8,18 @@ set -e
 case "$(uname -s)" in
   Darwin*)
     echo "macOS detected - running brew bundle..."
-    
+
+    # Homebrew may not be in PATH yet if install-packages.sh just installed it
+    # (chezmoi runs each script in a separate shell). Resolve from known paths.
     if ! command -v brew >/dev/null 2>&1; then
-      echo "Error: Homebrew is not installed. Please run the main install script first."
-      exit 1
+      if [ -f /opt/homebrew/bin/brew ]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+      elif [ -f /usr/local/bin/brew ]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+      else
+        echo "Error: Homebrew is not installed. Please run the main install script first."
+        exit 1
+      fi
     fi
     
     # Use the Brewfile from the home directory (after chezmoi applies it)


### PR DESCRIPTION
## Summary
- chezmoi runs each script in a separate shell, so PATH changes from `install-packages.sh` don't persist to `install-brewfile.sh`
- On CI (and fresh installs), Homebrew is installed by `run_once_install-packages.sh` but `run_onchange_install-brewfile.sh` fails because `brew` isn't in PATH yet
- Added PATH resolution from `/opt/homebrew/bin/brew` and `/usr/local/bin/brew` before falling back to the error — same pattern already used in `install-packages.sh`

## Test plan
- [ ] macOS CI job passes (previously failing with "Homebrew is not installed")
- [ ] Ubuntu and Windows CI jobs unaffected (script exits early on non-macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)