### PR TITLE
fix(brew): ensure install-packages runs before install-brewfile

### DIFF
--- a/home/run_once_before_install-packages.sh.tmpl
+++ b/home/run_once_before_install-packages.sh.tmpl
@@ -105,12 +105,7 @@ case "$(uname -s)" in
       echo "Installing Homebrew..."
       /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       # Add Homebrew to PATH for the remainder of this script
-      # (Apple Silicon installs to /opt/homebrew, Intel to /usr/local)
-      if [ -f /opt/homebrew/bin/brew ]; then
-        eval "$(/opt/homebrew/bin/brew shellenv)"
-      elif [ -f /usr/local/bin/brew ]; then
-        eval "$(/usr/local/bin/brew shellenv)"
-      fi
+      eval "$(/opt/homebrew/bin/brew shellenv)"
     fi
     echo "Installing packages with Homebrew..."
     # Add packages here

--- a/home/run_onchange_install-brewfile.sh.tmpl
+++ b/home/run_onchange_install-brewfile.sh.tmpl
@@ -14,8 +14,6 @@ case "$(uname -s)" in
     if ! command -v brew >/dev/null 2>&1; then
       if [ -f /opt/homebrew/bin/brew ]; then
         eval "$(/opt/homebrew/bin/brew shellenv)"
-      elif [ -f /usr/local/bin/brew ]; then
-        eval "$(/usr/local/bin/brew shellenv)"
       else
         echo "Error: Homebrew is not installed. Please run the main install script first."
         exit 1


### PR DESCRIPTION
## Summary
- Root cause: chezmoi sorts scripts alphabetically by target name, so `install-brewfile.sh` ran **before** `install-packages.sh` — Homebrew wasn't installed yet
- Rename to `run_once_before_install-packages.sh` so the Homebrew bootstrap runs before all other scripts
- Drop Intel (`/usr/local`) path fallbacks (Apple Silicon only)

## Test plan
- [ ] macOS CI job passes (previously failing with "Homebrew is not installed")
- [ ] Ubuntu and Windows CI jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)