### PR TITLE
feat(brew): add pandoc to personal macOS profile

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -42,6 +42,7 @@
                 "nvm",
                 "openjdk",
                 "openssl",
+                "pandoc",
                 "podman",
                 "powershell/tap/powershell",
                 "powershell",


### PR DESCRIPTION
## Summary
- Add `pandoc` to the personal macOS Homebrew formulas list

## Test plan
- [ ] CI lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)