### PR TITLE
feat(starship): add two-line prompt layout

### DIFF
--- a/home/dot_config/starship.toml
+++ b/home/dot_config/starship.toml
@@ -7,7 +7,8 @@ command_timeout = 2000
 add_newline = true
 
 # Set the format of the prompt
-format = """$os$username$directory$git_branch$git_status$nodejs$golang$julia$python$ruby$character"""
+format = """$os$username$directory$git_branch$git_status$nodejs$golang$julia$python$ruby\
+$line_break$character"""
 
 # Right Prompt Configuration
 right_format = """$cmd_duration$shell$battery$time"""


### PR DESCRIPTION
## Summary
- Add `$line_break` before `$character` in the Starship format string
- Moves the input cursor to its own line, preventing long paths and git status from pushing the typing area to the right

## Test plan
- [ ] Verify `chezmoi diff` shows the expected change to `~/.config/starship.toml`
- [ ] Confirm prompt renders with input on a new line after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)