### PR TITLE
feat(config): add Ghostty working directory and trackpad tap-to-click

### DIFF
--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -1,3 +1,5 @@
 # Ghostty terminal configuration
 # Docs: https://ghostty.org/docs/config
 # Defaults: ghostty +show-config --default --docs
+
+working-directory = ~/dev

--- a/home/run_once_macos_defaults.sh
+++ b/home/run_once_macos_defaults.sh
@@ -62,6 +62,11 @@ case "$(uname -s)" in
     # Disable the sound effects on boot
     sudo nvram SystemAudioVolume=" " || true
     
+    # Enable tap to click on trackpad
+    defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
+    defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
+    defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
+
     # Enable full keyboard access for all controls (e.g. enable Tab in modal dialogs)
     defaults write NSGlobalDomain AppleKeyboardUIMode -int 3
     


### PR DESCRIPTION
## Summary
- Set Ghostty default working directory to `~/dev`
- Enable trackpad tap-to-click in macOS defaults script

## Test plan
- [ ] Verify new Ghostty windows open in `~/dev`
- [ ] Run `run_once_macos_defaults.sh` and confirm tap-to-click works after logout/login

🤖 Generated with [Claude Code](https://claude.com/claude-code)