### PR TITLE
fix(pre-commit): correct markdownlint-cli2 repo URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/DavidAnson/markdownlint-cli2-repo
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.12.1
     hooks:
       - id: markdownlint-cli2


### PR DESCRIPTION
## Summary
- Fix incorrect repo URL in `.pre-commit-config.yaml` (`markdownlint-cli2-repo` → `markdownlint-cli2`)
- This was causing all pre-commit and pre-push hooks to fail with "repository not found"

## Test plan
- [ ] Verify `pre-commit run --all-files` succeeds after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)