### PR TITLE
feat(install): add Rosetta 2 installation on Apple Silicon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,13 @@ case "$(uname -s)" in
       fi
     fi
     echo "Homebrew: OK"
+
+    # Install Rosetta 2 on Apple Silicon (required by many Intel-based apps)
+    if [ "$(uname -m)" = "arm64" ] && ! /usr/bin/pgrep -q oahd; then
+      echo "Installing Rosetta 2..."
+      softwareupdate --install-rosetta --agree-to-license
+    fi
+    echo "Rosetta 2: OK"
     ;;
 
   Linux*)


### PR DESCRIPTION
## Summary
- Installs Rosetta 2 non-interactively during macOS bootstrap on Apple Silicon Macs
- Skips if already installed (detected via `oahd` daemon)
- Needed by many apps that ship Intel-only binaries (Steam, etc.)

## Test plan
- [ ] Verify on Apple Silicon Mac with Rosetta already installed (should skip)
- [ ] Verify `install.sh` still passes CI on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)