### PR TITLE
feat(starship): add transient prompt

### DIFF
--- a/home/dot_config/starship.toml
+++ b/home/dot_config/starship.toml
@@ -73,6 +73,9 @@ success_symbol = "[󰄾](bold green)"
 error_symbol = "[󰄾](bold red)"
 vicmd_symbol = "[❮](bold green)"
 
+[transient_prompt]
+format = "[󰄾](bold green) "
+
 [nodejs]
 format = "[ $version](fg:#6CA35E) "
 detect_files = ["package.json", ".node-version"]


### PR DESCRIPTION
## Summary
- Adds `[transient_prompt]` to collapse previous prompts to just the prompt character
- Keeps terminal scrollback clean while current prompt retains full context

## Test plan
- [ ] Verify previous prompts collapse after running commands
- [ ] Verify current prompt still shows full info (os, user, dir, git, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)