### PR TITLE
feat(brew): add Microsoft Office to personal macOS profile

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -70,6 +70,7 @@
                 "gcloud-cli",
                 "insomnia",
                 "logi-options+",
+                "microsoft-office",
                 "rectangle",
                 "steam",
                 "visual-studio-code",


### PR DESCRIPTION
## Summary
- Adds `microsoft-office` cask to the personal macOS Homebrew profile
- Installs Word, Excel, PowerPoint, Outlook, OneNote, and OneDrive

## Test plan
- [ ] Verify `chezmoi apply` generates Brewfile with `microsoft-office` cask
- [ ] Verify `brew install --cask microsoft-office` installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)