### PR TITLE
fix(nano): remove deprecated smooth scrolling option

### DIFF
--- a/home/dot_nanorc
+++ b/home/dot_nanorc
@@ -1,8 +1,5 @@
 # Nano configuration
 
-# Use smooth scrolling
-set smooth
-
 # Show line numbers
 set linenumbers
 


### PR DESCRIPTION
## Summary

- Remove `set smooth` from `.nanorc` — this option was removed in nano 8.x (smooth scrolling is now the default)
- Fixes: `Error in /Users/paul/.nanorc on line 4: Unknown option: smooth`

## Test plan

- [ ] Open nano and confirm no startup error

🤖 Generated with [Claude Code](https://claude.com/claude-code)