### PR TITLE
docs(claude): add commit style guidelines

### DIFF
--- a/home/dot_claude/CLAUDE.md.tmpl
+++ b/home/dot_claude/CLAUDE.md.tmpl
@@ -8,10 +8,11 @@
 - Don't merge your own PRs - let them be reviewed by someone else
 - Before pushing follow-up commits to a PR branch, always check the PR is still open (`gh pr view <number> --json state`). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead
 
-## Commit Style
+## Commit & PR Style
 
-- Use `git commit -m "Title\n\nBody\n\nCo-Authored-By: ..."` with `\n` for linebreaks
-- Do NOT use heredocs (`cat <<'EOF'`) in commit commands — they create multi-line bash that doesn't match the `Bash(git commit *)` permission rule, causing unnecessary permission prompts
+- Use `git commit -m $'Title\n\nBody\n\nCo-Authored-By: ...'` with `\n` for linebreaks
+- Use `gh pr create --title "..." --body $'## Summary\n\n- ...'` with `\n` for linebreaks
+- Do NOT use heredocs (`cat <<'EOF'`) in bash commands — they create multi-line bash that doesn't match permission rules like `Bash(git commit *)` and `Bash(gh pr create *)`, causing unnecessary permission prompts
 
 ## Process Guidelines
 

--- a/home/dot_claude/CLAUDE.md.tmpl
+++ b/home/dot_claude/CLAUDE.md.tmpl
@@ -8,6 +8,11 @@
 - Don't merge your own PRs - let them be reviewed by someone else
 - Before pushing follow-up commits to a PR branch, always check the PR is still open (`gh pr view <number> --json state`). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead
 
+## Commit Style
+
+- Use `git commit -m "Title\n\nBody\n\nCo-Authored-By: ..."` with `\n` for linebreaks
+- Do NOT use heredocs (`cat <<'EOF'`) in commit commands — they create multi-line bash that doesn't match the `Bash(git commit *)` permission rule, causing unnecessary permission prompts
+
 ## Process Guidelines
 
 - **3 strikes rule**: After 3 failed attempts debugging the same issue, stop and question the entire approach before trying again


### PR DESCRIPTION
## Summary

- Adds a **Commit Style** section to the global CLAUDE.md template
- Instructs Claude Code to use single-line `git commit -m` with `\n` for linebreaks instead of heredocs
- Heredocs (`cat <<'EOF'`) create multi-line bash that doesn't match the `Bash(git commit *)` permission rule, causing unnecessary permission prompts

## Test plan

- [ ] Verify `chezmoi apply` renders the template correctly
- [ ] Confirm the new section appears in `~/.claude/CLAUDE.md` after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)