### PR TITLE
fix(dotup): auto-confirm starship update to avoid pager prompt

### DIFF
--- a/home/dot_config/zsh/aliases.zsh
+++ b/home/dot_config/zsh/aliases.zsh
@@ -30,7 +30,7 @@ dotup() {
   if [ "$(uname -s)" = "Linux" ] && ! command -v brew >/dev/null 2>&1 \
      && command -v starship >/dev/null 2>&1; then
     echo "\n==> Updating Starship..."
-    curl -sS https://starship.rs/install.sh | sh
+    curl -sS https://starship.rs/install.sh | sh -s -- -y
   fi
 
   if command -v rustup >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Add `-y` flag to starship install script in `dotup` to auto-accept updates without showing a diff pager that requires pressing `q` to exit
- Matches the `-y` flag already used in the install script (`run_once_before_install-packages.sh.tmpl`)

## Test plan

- [ ] Run `dotup` on Linux — starship update should complete without a pager prompt

Generated with [Claude Code](https://claude.ai/code)