### PR TITLE
feat(config): align dotfiles with cloud-coop VM settings

### DIFF
--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -27,7 +27,7 @@
 	templateDir = ~/.git-templates
 
 [pull]
-	rebase = false
+	rebase = true
 
 [push]
 	default = simple

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -8,8 +8,16 @@ bind-key C-a send-prefix
 # Enable mouse support
 set -g mouse on
 
-# Set default terminal to support 256 colors
-set -g default-terminal "screen-256color"
+# Allow passthrough of OSC sequences (enables clickable hyperlinks in Ghostty)
+set -g allow-passthrough on
+
+# Enable focus events
+set -g focus-events on
+
+# Modern terminal settings
+set -g default-terminal "tmux-256color"
+set -as terminal-features ",xterm-256color:RGB"
+set -as terminal-features ",*:hyperlinks"
 
 # Start window numbering at 1 instead of 0
 set -g base-index 1
@@ -19,7 +27,7 @@ set -g pane-base-index 1
 set -g renumber-windows on
 
 # Increase scrollback buffer size
-set -g history-limit 10000
+set -g history-limit 50000
 
 # Use vi mode for copy mode
 setw -g mode-keys vi

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -10,8 +10,14 @@ export ZSH=$HOME/.oh-my-zsh
 # Ensure local bin is in PATH
 export PATH="$HOME/.local/bin:$PATH"
 
-# Ensure homebrew bin path is in PATH
-export PATH="/opt/homebrew/bin:$PATH"
+# Homebrew
+{{- if eq .chezmoi.os "darwin" }}
+eval "$(/opt/homebrew/bin/brew shellenv)"
+{{- else if eq .chezmoi.os "linux" }}
+if [ -d /home/linuxbrew/.linuxbrew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+{{- end }}
 
 # Ensure cargo bin is in PATH (Rust toolchain)
 export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
## Summary
- **tmux**: Add allow-passthrough, focus-events, terminal-features for Ghostty hyperlinks/RGB; upgrade to tmux-256color; bump history-limit to 50000
- **git**: Change pull.rebase to true for cleaner history on shared branches
- **zsh**: Convert to chezmoi template with OS-conditional brew shellenv so Homebrew paths work on both macOS and Linux

## Context
Analysis of cloud-coop provision-vm.sh revealed several modern terminal settings missing from dotfiles, and a hardcoded macOS Homebrew path that would break on Linux VMs.

## Test plan
- [ ] Verify chezmoi apply works on macOS (brew shellenv resolves /opt/homebrew)
- [ ] Verify tmux mouse scroll and hyperlinks work in Ghostty
- [ ] Verify git pull now rebases by default