### PR TITLE
fix(brew): restore Brewfile install on first run

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -25,7 +25,7 @@ run_once_install-packages.sh
 install-packages.sh
 run_once_macos_defaults.sh
 macos_defaults.sh
-run_onchange_install-brewfile.sh
+run_once_after_install-brewfile.sh
 install-brewfile.sh
 run_onchange_install-ubuntu-packages.sh
 install-ubuntu-packages.sh
@@ -51,7 +51,7 @@ setup-secrets.sh
 {{- if ne .chezmoi.os "darwin" }}
 run_once_macos_defaults.sh
 macos_defaults.sh
-run_onchange_install-brewfile.sh
+run_once_after_install-brewfile.sh
 install-brewfile.sh
 Brewfile
 {{- end }}

--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Install Homebrew packages from Brewfile on first run
+# Subsequent updates are handled manually via 'dotbrew'
+
+set -e
+
+case "$(uname -s)" in
+  Darwin*)
+    # Ensure Homebrew is in PATH
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+
+    BREWFILE="$HOME/Brewfile"
+    if [ -f "$BREWFILE" ]; then
+      echo "Installing Homebrew packages from Brewfile..."
+      brew bundle install --file "$BREWFILE" --no-lock
+    else
+      echo "Warning: Brewfile not found at $BREWFILE, skipping brew bundle"
+    fi
+    ;;
+  *)
+    echo "Not macOS — skipping Brewfile install"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add `run_once_after_install-brewfile.sh.tmpl` to run `brew bundle install` on initial `chezmoi apply`
- The `run_onchange` auto-install script was removed in #91 but that also broke first-install — git-delta, lazygit, tmux (and all other Brewfile packages) were never installed
- Subsequent updates remain manual via `dotbrew`
- Update `.chezmoiignore` references from `run_onchange` to `run_once_after`

## Test plan
- [ ] CI macOS job passes (git-delta, lazygit, tmux now installed)
- [ ] Fresh `chezmoi init --apply` installs Brewfile packages on macOS
- [ ] Linux/Windows unaffected (script is ignored via .chezmoiignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)