### PR TITLE
fix(brew): use env var instead of invalid --no-lock flag

### DIFF
--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -13,7 +13,7 @@ case "$(uname -s)" in
     BREWFILE="$HOME/Brewfile"
     if [ -f "$BREWFILE" ]; then
       echo "Installing Homebrew packages from Brewfile..."
-      brew bundle install --file "$BREWFILE" --no-lock
+      HOMEBREW_BUNDLE_NO_LOCK=1 brew bundle install --file "$BREWFILE"
     else
       echo "Warning: Brewfile not found at $BREWFILE, skipping brew bundle"
     fi


### PR DESCRIPTION
## Summary
- `brew bundle install --no-lock` is not a valid flag — it caused CI to fail immediately
- Use `HOMEBREW_BUNDLE_NO_LOCK=1` env var instead to skip generating Brewfile.lock.json

## Test plan
- [ ] CI macOS job passes the brew bundle install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)