### PR TITLE
feat(cloudcoop): add default config for personal machines

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -64,6 +64,11 @@ configure-wsl.sh
 .config/ubuntu_pkglist
 {{- end }}
 
+# Only deploy cloudcoop config on personal machines
+{{- if ne $machineType "personal" }}
+.config/cloudcoop/
+{{- end }}
+
 # Skip GUI app configs on minimal/server machines
 {{- if eq $machineType "minimal" }}
 .config/Code/

--- a/home/dot_config/cloudcoop/cloudcoop.toml
+++ b/home/dot_config/cloudcoop/cloudcoop.toml
@@ -1,0 +1,17 @@
+[cloud.gcp]
+zone = "europe-north2-a"
+
+[ssh]
+port = 2022
+
+[vm]
+spot = true
+network = "sandbox-vpc"
+subnet = "sandbox-vpc-europe-north2"
+max_uptime_minutes = 480
+
+[agents]
+default_command = "claude"
+
+[provisioning]
+dotfiles_url = "https://raw.githubusercontent.com/pmgledhill102/dotfiles/main/install.sh"


### PR DESCRIPTION
## Summary
- Add `~/.config/cloudcoop/cloudcoop.toml` with GCP europe-north2 defaults, sandbox VPC, spot VMs, and dotfiles provisioning URL
- Only deployed on `machine_type = personal` (ignored for work/minimal via .chezmoiignore)

## Test plan
- [ ] `chezmoi apply` deploys config on personal machine type
- [ ] Config is not deployed on work/minimal machine types

🤖 Generated with [Claude Code](https://claude.com/claude-code)