### PR TITLE
fix(dotup): disable pager for chezmoi update

### DIFF
--- a/home/dot_config/zsh/aliases.zsh
+++ b/home/dot_config/zsh/aliases.zsh
@@ -7,7 +7,7 @@
 # Update dotfiles and plugins (does not install/upgrade packages)
 dotup() {
   echo "==> Updating dotfiles..."
-  chezmoi update -v
+  PAGER=cat chezmoi update -v
 
   if [ -d "$ZSH" ]; then
     echo "\n==> Updating Oh My Zsh..."


### PR DESCRIPTION
## Summary

- Override `PAGER=cat` for `chezmoi update -v` in `dotup` to prevent bat from blocking on diff output
- Root cause: `export PAGER=bat` in `aliases.zsh` causes chezmoi to pipe verbose diff through bat, requiring `q` to quit

## Test plan

- [ ] Run `dotup` and verify chezmoi update output streams without requiring `q` to dismiss

Generated with [Claude Code](https://claude.com/claude-code)