### PR TITLE
fix(brew): remove nonexistent github/github-mcp-server tap

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -3,7 +3,6 @@
 
 {{- if eq .machine_type "personal" }}
 tap "aws/tap"
-tap "github/github-mcp-server"
 
 brew "actionlint"
 brew "aws-sam-cli"


### PR DESCRIPTION
## Summary

- Remove `tap "github/github-mcp-server"` from Brewfile — formula is in homebrew-core, no tap needed
- This was lost during squash merge of #113

## Test plan

- [ ] `dotbrew` runs without tap errors

Generated with [Claude Code](https://claude.com/claude-code)