### PR TITLE
feat(dotclaude): add cship statusline for Claude Code

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -54,6 +54,8 @@ macos_defaults.sh
 run_once_after_install-brewfile.sh
 install-brewfile.sh
 Brewfile
+run_onchange_after_install-cship.sh
+install-cship.sh
 {{- end }}
 
 {{- if ne .chezmoi.os "linux" }}
@@ -65,8 +67,11 @@ configure-wsl.sh
 {{- end }}
 
 # Only deploy cloudcoop config on personal machines
+# cship install script is macOS personal only
 {{- if ne $machineType "personal" }}
 .config/cloudcoop/
+run_onchange_after_install-cship.sh
+install-cship.sh
 {{- end }}
 
 # Skip GUI app configs on minimal/server machines

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -302,5 +302,9 @@
       }
     ]
   },
-  "effortLevel": "high"
+  "effortLevel": "high",
+  "statusLine": {
+    "type": "command",
+    "command": "cship"
+  }
 }

--- a/home/dot_claude/settings.json.md
+++ b/home/dot_claude/settings.json.md
@@ -488,3 +488,24 @@ Runs `bd prime` before context compaction to preserve task state.
 ### SessionStart
 
 Runs `bd prime` at session start to load task context.
+
+## StatusLine
+
+Custom status line rendered by [cship](https://github.com/stephenleo/cship)
+(v1.4.1, pinned to commit `1e5940e`). Claude Code pipes session JSON to
+cship's stdin on every render cycle; cship outputs styled ANSI text for
+the TUI status bar.
+
+Config lives at `~/.config/cship.toml`. Usage limits module is disabled
+(credential access not needed — `/usage` and the built-in 90% warning
+are sufficient).
+
+```json
+"statusLine": {
+  "type": "command",
+  "command": "cship"
+}
+```
+
+On machines without `cship` installed, Claude Code silently falls back
+to the default status line.

--- a/home/dot_config/cship.toml
+++ b/home/dot_config/cship.toml
@@ -1,0 +1,36 @@
+# cship — Claude Code statusline
+# https://cship.dev
+#
+# Complementary to starship.toml (shell prompt). CShip renders inside
+# the Claude Code TUI statusline, not in the terminal prompt.
+# Passthrough modules ($directory, $git_branch, etc.) invoke starship
+# and inherit formatting from ~/.config/starship.toml.
+
+[cship]
+lines = [
+  "$directory$git_branch$git_status$battery$time",
+  "$cship.model $cship.cost $cship.context_bar"
+]
+
+[cship.model]
+symbol = "  "
+style  = "bold cyan"
+
+[cship.context_bar]
+width              = 10
+style              = "fg:#7dcfff"
+warn_threshold     = 40.0
+warn_style         = "fg:#e0af68"
+critical_threshold = 70.0
+critical_style     = "bold fg:#f7768e"
+
+[cship.cost]
+symbol             = "  "
+style              = "fg:#a9b1d6"
+warn_threshold     = 2.0
+warn_style         = "fg:#e0af68"
+critical_threshold = 5.0
+critical_style     = "bold fg:#f7768e"
+
+[cship.usage_limits]
+disabled = true

--- a/home/run_onchange_after_install-cship.sh.tmpl
+++ b/home/run_onchange_after_install-cship.sh.tmpl
@@ -1,0 +1,37 @@
+{{- if and (eq .chezmoi.os "darwin") (eq .machine_type "personal") -}}
+#!/bin/sh
+# Install cship — Claude Code statusline renderer
+# https://github.com/stephenleo/cship
+#
+# Pinned to audited commit (v1.4.1). Change the hash below to upgrade;
+# run_onchange_ will re-run automatically on content change.
+#
+# Security audit: 2026-04-04, commit 1e5940e2a051288107f729ca43f912c8db41bae1
+# - No unsafe in application code
+# - Single network call to api.anthropic.com (disabled via config)
+# - No shell evaluation, no telemetry
+# - Subprocess calls only to starship and OS credential tools
+
+set -e
+
+CSHIP_COMMIT="1e5940e2a051288107f729ca43f912c8db41bae1"
+
+# Ensure cargo is available
+if ! command -v cargo >/dev/null 2>&1; then
+  if [ -f "$HOME/.cargo/env" ]; then
+    . "$HOME/.cargo/env"
+  else
+    echo "cship: cargo not found, skipping install"
+    exit 0
+  fi
+fi
+
+echo "Installing cship from pinned commit ${CSHIP_COMMIT}..."
+cargo install --git https://github.com/stephenleo/cship --rev "$CSHIP_COMMIT" cship
+
+echo "cship installed successfully"
+cship explain 2>/dev/null || true
+{{- else -}}
+#!/bin/sh
+# cship install — skipped (macOS personal only)
+{{- end }}


### PR DESCRIPTION
## Summary

- Add [cship](https://github.com/stephenleo/cship) v1.4.1 as a custom Claude Code statusline renderer
- Pinned to audited commit `1e5940e2a051288107f729ca43f912c8db41bae1` — full security review of all 22 Rust source files performed
- Two-line statusline: starship passthrough (directory, git, battery, time) + Claude-specific info (model, cost, context bar)
- Install via `cargo install --git --rev` from source, gated to macOS personal
- Usage limits module disabled (not needed with `/usage` and built-in 90% warning)

## Files

| File | Purpose |
|------|---------|
| `home/dot_config/cship.toml` | CShip config — passthrough line + Claude info line |
| `home/dot_claude/settings.json` | Added `statusLine` command entry |
| `home/dot_claude/settings.json.md` | Documented statusLine with audit info |
| `home/run_onchange_after_install-cship.sh.tmpl` | Install script (macOS personal only, `run_onchange_` for version bumps) |
| `home/.chezmoiignore` | Gate install script to macOS personal |

## Security audit highlights (commit 1e5940e)

- No `unsafe` in application code (only in `#[cfg(test)]` for `set_var`)
- Single network call to `api.anthropic.com` (disabled in our config)
- No shell evaluation, no telemetry, no file writes outside cache dir
- 10 well-known runtime deps (clap, serde, toml, ureq, etc.)
- Release binaries built from source by GitHub Actions CI

## Test plan

- [ ] `chezmoi apply --dry-run` shows cship.toml and settings.json changes
- [ ] Install script renders correctly on macOS personal (`chezmoi execute-template`)
- [ ] Install script is skipped on non-macOS / non-personal machines
- [ ] `cargo install --git --rev 1e5940e...` builds successfully
- [ ] Claude Code picks up statusline after restart
- [ ] CI passes (shellcheck, markdownlint, actionlint)

Generated with [Claude Code](https://claude.com/claude-code)