### PR TITLE
fix(cship): add --force flag and drop battery/time from statusline

### DIFF
--- a/home/dot_config/cship.toml
+++ b/home/dot_config/cship.toml
@@ -8,7 +8,7 @@
 
 [cship]
 lines = [
-  "$directory$git_branch$git_status$battery$time",
+  "$directory$git_branch$git_status",
   "$cship.model $cship.cost $cship.context_bar"
 ]
 

--- a/home/run_onchange_after_install-cship.sh.tmpl
+++ b/home/run_onchange_after_install-cship.sh.tmpl
@@ -27,7 +27,7 @@ if ! command -v cargo >/dev/null 2>&1; then
 fi
 
 echo "Installing cship from pinned commit ${CSHIP_COMMIT}..."
-cargo install --git https://github.com/stephenleo/cship --rev "$CSHIP_COMMIT" cship
+cargo install --force --git https://github.com/stephenleo/cship --rev "$CSHIP_COMMIT" cship
 
 echo "cship installed successfully"
 cship explain 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add `--force` to `cargo install` so version upgrades work reliably when only the commit hash changes (version string in Cargo.toml may stay the same between commits)
- Remove battery and time passthrough modules from cship statusline — they clash with Claude Code's own right-aligned status text

Generated with [Claude Code](https://claude.com/claude-code)