### PR TITLE
feat(dotclaude): add retro recommendations and remove cship cost

### DIFF
--- a/home/dot_claude/CLAUDE.md.tmpl
+++ b/home/dot_claude/CLAUDE.md.tmpl
@@ -19,3 +19,10 @@
 - **3 strikes rule**: After 3 failed attempts debugging the same issue, stop and question the entire approach before trying again
 - **Check release notes before upgrading CLI tools**: Run `gh release view --repo <owner>/<repo>` or check the changelog before upgrading. Breaking changes (e.g., dropped backends, renamed flags) waste significant time when discovered mid-migration
 - **Test chezmoi template changes locally before pushing**: Use `HOME=/tmp/test chezmoi init --source <path> --dry-run` to verify behaviour in a clean environment before relying on CI
+- **Lint before pushing**: Always run the relevant linter/test suite locally before `git push`. Only push if everything passes — avoids CI round-trips
+- **Single-concern PRs**: Each PR should contain a single logical change. If multiple tasks are completed in a session, create separate PRs for each rather than bundling unrelated changes
+
+## Shell Scripts
+
+- **Target POSIX sh or ensure macOS/zsh compatibility**: Avoid bash-only builtins (`mapfile`, `readarray`, `declare -A`). Be aware that `$(( expr ))` returns exit code 1 when result is 0 (breaks `set -e`), and empty arrays behave differently in zsh with `set -u`
+- **Verify CLI flags before using them**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing — avoids round-trips from non-existent flags (e.g., `brew bundle --no-lock`)

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -268,6 +268,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command // empty'); case \"$CMD\" in 'git push'*) if [ -f .pre-commit-config.yaml ]; then pre-commit run --all-files || { echo 'Pre-push lint check failed. Fix issues before pushing.'; exit 1; }; fi;; esac",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/home/dot_claude/settings.json.md
+++ b/home/dot_claude/settings.json.md
@@ -472,6 +472,13 @@ the user revisits it.
 
 ## Hooks
 
+### PreToolUse (Bash)
+
+1. **Pre-push lint gate** — Intercepts `git push` commands and runs
+   `pre-commit run --all-files` if a `.pre-commit-config.yaml` exists in
+   the repo. Blocks the push if linting fails. 120s timeout. Repos without
+   pre-commit config are unaffected.
+
 ### PostToolUse (Write|Edit)
 
 1. **terraform fmt** — Auto-formats `.tf` files after every Write or Edit.

--- a/home/dot_config/cship.toml
+++ b/home/dot_config/cship.toml
@@ -9,7 +9,7 @@
 [cship]
 lines = [
   "$directory$git_branch$git_status",
-  "$cship.model $cship.cost $cship.context_bar"
+  "$cship.model $cship.context_bar"
 ]
 
 [cship.model]
@@ -22,14 +22,6 @@ style              = "fg:#7dcfff"
 warn_threshold     = 40.0
 warn_style         = "fg:#e0af68"
 critical_threshold = 70.0
-critical_style     = "bold fg:#f7768e"
-
-[cship.cost]
-symbol             = "  "
-style              = "fg:#a9b1d6"
-warn_threshold     = 2.0
-warn_style         = "fg:#e0af68"
-critical_threshold = 5.0
 critical_style     = "bold fg:#f7768e"
 
 [cship.usage_limits]


### PR DESCRIPTION
## Summary

Implements actionable recommendations from retrospective analysis (2026-03-21 to 2026-04-04):

- **Pre-push lint hook** (`PreToolUse`): intercepts `git push` and runs `pre-commit run --all-files` if the repo has a `.pre-commit-config.yaml`. Blocks push on lint failure. Addresses the #1 friction pattern from Insights (30 buggy code events from pushing before linting)
- **CLAUDE.md — lint before pushing**: rule to always run linters locally before `git push`
- **CLAUDE.md — single-concern PRs**: each PR should contain one logical change
- **CLAUDE.md — shell script compatibility**: target POSIX sh / macOS zsh, avoid bashisms, verify CLI flags before using
- **cship**: remove cost module from statusline (not useful on Max plan)

## Retro items closed

| Retro | Recommendation | Status |
|-------|---------------|--------|
| 2026-04-04 Insights | Pre-push linting hook | Done |
| 2026-04-04 Insights | Encode "run CI checks locally before pushing" | Done |
| 2026-04-04 Insights | Single-concern PR rule | Done |
| 2026-04-04 Insights | macOS/zsh shell compatibility rule | Done |
| 2026-03-30 Dotfiles | Verify CLI flags before using | Done |

Generated with [Claude Code](https://claude.com/claude-code)