### PR TITLE
docs(dotclaude): prefer GitHub MCP over gh CLI

### DIFF
--- a/home/dot_claude/CLAUDE.md.tmpl
+++ b/home/dot_claude/CLAUDE.md.tmpl
@@ -1,23 +1,28 @@
 # CLAUDE.md
 
+## GitHub MCP
+
+- **Prefer `mcp__github__*` tools over the `gh` CLI for all GitHub operations** when the GitHub MCP server is connected. Only fall back to `gh` if the MCP server is unavailable or a specific capability is missing
+- Common mappings: PRs (`create_pull_request`, `pull_request_read`, `update_pull_request`, `merge_pull_request`, `list_pull_requests`, `search_pull_requests`), reviews (`pull_request_review_write`, `add_comment_to_pending_review`, `add_reply_to_pull_request_comment`), issues (`issue_read`, `issue_write`, `list_issues`, `search_issues`, `add_issue_comment`), releases (`get_latest_release`, `list_releases`, `get_release_by_tag`), repo content (`get_file_contents`, `list_commits`, `get_commit`, `list_branches`, `create_branch`), search (`search_code`, `search_repositories`)
+- PR review workflow: create a pending review with `pull_request_review_write` (method: "create"), add line comments with `add_comment_to_pending_review`, then submit with `pull_request_review_write` (method: "submit_pending")
+
 ## Git Workflow
 
 - Always create feature branches for changes -- never commit directly to main
-- Create pull requests and merge via `gh pr merge --squash --delete-branch`
+- Create PRs with `mcp__github__create_pull_request` and merge via `mcp__github__merge_pull_request` (method: "squash", delete_branch: true)
 - Watch the CI checks and ensure they pass
 - Don't merge your own PRs - let them be reviewed by someone else
-- Before pushing follow-up commits to a PR branch, always check the PR is still open (`gh pr view <number> --json state`). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead
+- Before pushing follow-up commits to a PR branch, always check the PR is still open via `mcp__github__pull_request_read` (method: "get"). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead
 
 ## Commit & PR Style
 
 - Use multiple `-m` flags for multi-paragraph commit messages: `git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`
-- Use plain double-quoted strings for PR creation: `gh pr create --title "Title" --body "## Summary ..."`
 - Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in bash commands — heredocs create multi-line bash that doesn't match permission rules, and ANSI-C quoting gets flagged for hiding characters
 
 ## Process Guidelines
 
 - **3 strikes rule**: After 3 failed attempts debugging the same issue, stop and question the entire approach before trying again
-- **Check release notes before upgrading CLI tools**: Run `gh release view --repo <owner>/<repo>` or check the changelog before upgrading. Breaking changes (e.g., dropped backends, renamed flags) waste significant time when discovered mid-migration
+- **Check release notes before upgrading CLI tools**: Use `mcp__github__get_latest_release` / `mcp__github__list_releases` or check the changelog before upgrading. Breaking changes (e.g., dropped backends, renamed flags) waste significant time when discovered mid-migration
 - **Test chezmoi template changes locally before pushing**: Use `HOME=/tmp/test chezmoi init --source <path> --dry-run` to verify behaviour in a clean environment before relying on CI
 - **Lint before pushing**: Always run the relevant linter/test suite locally before `git push`. Only push if everything passes — avoids CI round-trips
 - **Single-concern PRs**: Each PR should contain a single logical change. If multiple tasks are completed in a session, create separate PRs for each rather than bundling unrelated changes


### PR DESCRIPTION
## Summary

Adds a dedicated **GitHub MCP** section to the machine-level `CLAUDE.md` template with a generic directive to prefer `mcp__github__*` tools over the `gh` CLI when the MCP server is connected, plus a grouped reference of common tool mappings and the pending-review workflow.

Replaces the four `gh` CLI references in Git Workflow / Process Guidelines with MCP equivalents, and drops the now-obsolete `gh pr create` shell-quoting guidance (MCP tools take native strings).

## Why

GitHub operations are roughly 50% of Claude's activity in this repo — making the MCP preference explicit (rather than implicit via memory) saves a round-trip every session and makes the guidance portable across accounts.

## Test plan

- [ ] CI passes (markdownlint skips `.tmpl` files, so no lint impact)
- [ ] `chezmoi apply` renders cleanly to `~/.claude/CLAUDE.md`
