### PR TITLE
feat(dotclaude): allow google-developer-knowledge MCP tools

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -252,6 +252,8 @@
       "mcp__github__sub_issue_write",
       "mcp__github__update_pull_request",
       "mcp__github__update_pull_request_branch",
+      "mcp__google-developer-knowledge__get_documents",
+      "mcp__google-developer-knowledge__search_documents",
       "Read(~/.claude/retros.md)",
       "Read(~/.claude/settings.json)"
     ]

--- a/home/dot_claude/settings.json.md
+++ b/home/dot_claude/settings.json.md
@@ -447,6 +447,11 @@ permissions below control which MCP tools are auto-approved.
 `create_repository`, `delete_file`, `fork_repository`,
 `merge_pull_request` (see Never Allow), `pull_request_review_write`.
 
+### Google Developer Knowledge MCP server (read-only)
+
+- `mcp__google-developer-knowledge__get_documents`
+- `mcp__google-developer-knowledge__search_documents`
+
 ### Read permissions (config files)
 
 Auto-approve reading config files accessed during every `/retrospective`


### PR DESCRIPTION
## Summary

- Add `mcp__google-developer-knowledge__get_documents` and `mcp__google-developer-knowledge__search_documents` to the auto-approved permissions list
- Both tools are read-only — no write/mutation risk

## Test plan

- [ ] `chezmoi apply` and verify `~/.claude/settings.json` contains the new entries
- [ ] Confirm both tools work without prompting in a new Claude Code session