### PR TITLE
feat(zsh): add dotfuncs to list installed custom shell functions

### DIFF
--- a/home/dot_config/zsh/functions/dotfuncs.zsh
+++ b/home/dot_config/zsh/functions/dotfuncs.zsh
@@ -1,0 +1,31 @@
+#!/bin/zsh
+# shellcheck disable=SC1071
+# List the custom shell functions installed by these dotfiles
+
+dotfuncs() {
+  local dir file name desc
+  dir="$HOME/.config/zsh/functions"
+
+  if [ ! -d "$dir" ]; then
+    echo "dotfuncs: no functions directory at ${dir}" >&2
+    return 1
+  fi
+
+  echo "Custom shell functions available:"
+  for file in "$dir"/*.zsh; do
+    [ -f "$file" ] || continue
+    name="${file##*/}"
+    name="${name%.zsh}"
+    # First comment line after the shebang and shellcheck pragma.
+    desc=$(awk '
+      /^#!/          { next }
+      /^# shellcheck/ { next }
+      /^#[[:space:]]/ {
+        sub(/^#[[:space:]]*/, "")
+        print
+        exit
+      }
+    ' "$file")
+    printf "  %-11s %s\n" "$name" "$desc"
+  done
+}

--- a/home/dot_config/zsh/functions/dotup.zsh
+++ b/home/dot_config/zsh/functions/dotup.zsh
@@ -46,4 +46,8 @@ dotup() {
   fi
 
   echo "\n==> All updates complete."
+
+  # Remind the user what custom commands are available post-update.
+  echo
+  dotfuncs
 }

--- a/home/dot_config/zsh/functions/note.zsh
+++ b/home/dot_config/zsh/functions/note.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # shellcheck disable=SC1071
-# Quick project-scoped notes
+# Quick project-scoped notes (also: notes, n alias)
 #
 # Notes are appended to ~/notes/<project>.md, where <project> is the git repo
 # basename when inside a repo, or the current directory basename otherwise.

--- a/install.sh
+++ b/install.sh
@@ -92,3 +92,16 @@ echo "Running chezmoi installation from branch: $BRANCH_NAME"
 sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin" init --apply --branch "$BRANCH_NAME" https://github.com/pmgledhill102/dotfiles.git
 
 echo "Installation complete!"
+
+# Print summary of installed custom shell functions, if any were deployed.
+# Sources them in a clean zsh subshell (install.sh is POSIX sh) and invokes
+# 'dotfuncs' to produce the list. Fail-safe — never blocks install.
+if command -v zsh >/dev/null 2>&1 && [ -d "$HOME/.config/zsh/functions" ]; then
+  echo ""
+  zsh -c '
+    for f in "$HOME/.config/zsh/functions"/*.zsh; do
+      [ -f "$f" ] && source "$f"
+    done
+    command -v dotfuncs >/dev/null 2>&1 && dotfuncs
+  ' 2>/dev/null || true
+fi


### PR DESCRIPTION
## Summary

Adds a new `dotfuncs` shell function that lists every custom shell function installed by these dotfiles, alongside a one-line description extracted automatically from each file's header comment. Called from `dotup` and `install.sh` so the user gets a reminder of what custom commands are available after every update and fresh install.

## Example output

```text
Custom shell functions available:
  dotbrew     Install and upgrade Homebrew packages from Brewfile
  dotclaude   Configure Claude Code MCP servers (interactive, personal machines only)
  dotfuncs    List the custom shell functions installed by these dotfiles
  dotstatus   Show dotfiles status: machine type, last applied, pending changes
  dotup       Update dotfiles and plugins (does not install/upgrade packages)
  note        Quick project-scoped notes (also: notes, n alias)
```

## How it works

- **`home/dot_config/zsh/functions/dotfuncs.zsh`** — new function. Iterates `~/.config/zsh/functions/*.zsh`, extracts the first non-shebang, non-shellcheck comment line from each file as the description, prints as a padded list. **Self-maintaining**: dropping a new `.zsh` file into that directory with a meaningful first comment is automatically picked up on the next `dotup` — no need to edit a central registry.
- **`home/dot_config/zsh/functions/dotup.zsh`** — calls `dotfuncs` at the end of every update so the user sees the list after `dotup` completes.
- **`install.sh`** — invokes `dotfuncs` via a clean `zsh -c` subshell (since `install.sh` is POSIX sh and can't source zsh files directly). Sources the newly-deployed functions, then runs `dotfuncs` if it's defined. Wrapped in `|| true` so a failure never blocks fresh-machine bootstrap.
- **`home/dot_config/zsh/functions/note.zsh`** — first-comment tweak from `Quick project-scoped notes` to `Quick project-scoped notes (also: notes, n alias)` so the dotfuncs output mentions the sibling `notes` and `n` that share the same file.

## Header comment convention (for future functions)

Every function file under `home/dot_config/zsh/functions/` should follow this header shape:

```zsh
#!/bin/zsh
# shellcheck disable=SC1071
# <Short description — first non-shebang, non-shellcheck comment line>
```

`dotfuncs` uses the first such line as the description shown in the list. Mention sibling functions or aliases inline when the file exposes more than one user-facing command.

## Test plan

- [x] `shellcheck` clean on all 4 touched files (`dotfuncs.zsh`, `dotup.zsh`, `note.zsh`, `install.sh`)
- [x] `dotfuncs` against a symlinked copy of the source `functions/` dir produces the expected 6-entry list (dotbrew, dotclaude, dotfuncs, dotstatus, dotup, note) with correct descriptions
- [x] `chezmoi init --apply --dry-run --verbose` renders all three `home/` files correctly
- [x] Manual inspection: `dotup` ends with the function listing; `install.sh` prints the listing after `chezmoi init --apply` in the bootstrap path
- [ ] CI: shellcheck / markdown-lint / actionlint / test-install matrix
- [ ] Manual end-to-end on the user's machine: merge, run `dotup`, confirm listing appears

## Independence from PR #125

This PR and #125 (`feat/note-cli-ergonomics`) both touch `note.zsh` but on disjoint lines — #125 modifies the option-parsing body and help text, this PR modifies only line 3 (the first header comment). Both can merge in either order with no conflict.

Closes dotfiles-pq7.

---

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;