### PR TITLE
fix(chezmoi): gate run_once_remove-claude-code-cask.sh to darwin only

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -27,6 +27,8 @@ run_once_macos_defaults.sh
 macos_defaults.sh
 run_once_after_install-brewfile.sh
 install-brewfile.sh
+run_once_remove-claude-code-cask.sh
+remove-claude-code-cask.sh
 run_onchange_install-ubuntu-packages.sh
 install-ubuntu-packages.sh
 run_once_configure-wsl.sh
@@ -53,6 +55,8 @@ run_once_macos_defaults.sh
 macos_defaults.sh
 run_once_after_install-brewfile.sh
 install-brewfile.sh
+run_once_remove-claude-code-cask.sh
+remove-claude-code-cask.sh
 Brewfile
 run_onchange_after_install-cship.sh
 install-cship.sh


### PR DESCRIPTION
## Summary

Fixes the Windows `test-install` CI job on main that has been failing on every push since PR #124. Adds `run_once_remove-claude-code-cask.sh` (and the unprefixed `remove-claude-code-cask.sh` form) to both the "Unix files ignored on Windows" block AND the "non-darwin" block of `home/.chezmoiignore`, matching the existing pattern for `run_once_after_install-brewfile.sh`.

## Root cause

PR #124 added a one-time migration script with a runtime `case "$(uname -s)"` guard that was supposed to no-op on non-macOS. But on **Windows, the runtime guard never fires** — Windows' `CreateProcess` rejects POSIX-shebang scripts entirely:

```
chezmoi: remove-claude-code-cask.sh: fork/exec C:\Users\RUNNER~1\AppData\Local\Temp\...: %1 is not a valid Win32 application.
```

The error comes from the kernel-level exec call, before any of the script's contents can run. The runtime `case` guard is moot because the script never gets to execute in the first place.

[Failing Windows job on main](https://github.com/pmgledhill102/dotfiles/actions/runs/24280292223/job/70901011995#step:10:5592) (from the PR #124 merge run).

## Fix

`home/.chezmoiignore` uses template conditionals to gate files per-OS. The existing `run_once_after_install-brewfile.sh` script has exactly the same macOS-only, brew-dependent scope as this one and is already listed in both the "Unix on Windows" block and the "non-darwin" block. Adding the same entries for the remove-cask script follows the established pattern.

## Verification

- **Template logic by inspection**:
  - On **Windows** (`os == windows`): the "Unix on Windows" block fires → script ignored ✓
  - On **Linux** (`os == linux`): the "non-darwin" block fires → script ignored ✓
  - On **macOS** (`os == darwin`): neither block fires → script deployed as before ✓
- **Local `chezmoi init --apply --dry-run --verbose` on macOS**: `remove-claude-code-cask.sh` still appears in the diff output, confirming it's still deployed on darwin
- Runtime `case "$(uname -s)"` guard in the script body is kept as belt-and-suspenders

## Test plan

- [x] Local macOS dry-run confirms script is still deployed
- [x] Template conditional logic walked through by hand for all three OSes
- [ ] CI: shellcheck / markdown-lint / actionlint / test-install matrix on Windows
- [ ] Post-merge: confirm the test-install-windows job on main turns green on the next push

Closes dotfiles-zg8.

---

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;