### PR TITLE
feat(ci): fast PR variant of test-install that skips package installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,18 +50,80 @@ jobs:
       - name: Run actionlint
         run: ./actionlint -color
 
-  # On PRs, report success without running the expensive full install.
-  # Uses the same job name so branch protection required checks are satisfied.
+  # Fast PR variant: runs chezmoi init --apply but skips the expensive package
+  # installs (brew / winget / apt) via the DOTFILES_SKIP_INSTALL=1 env var that
+  # template-gated scripts honour. Catches shebang/exec issues, template bugs,
+  # and chezmoiignore misconfigurations pre-merge. Target: ~3-5 min per OS vs
+  # ~22 min for the full test-install job which still runs on push-to-main.
+  # Uses the same matrix check name as the full job so branch protection rules
+  # are satisfied by either variant.
   test-install-pr:
     name: Test Install on ${{ matrix.os }}
     if: github.event_name == 'pull_request'
     needs: [shellcheck, markdown-lint, actionlint]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      DOTFILES_SKIP_INSTALL: '1'
+
     steps:
-      - run: echo "Skipping full install test on PR — lint checks only"
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+    - name: Install chezmoi (Unix)
+      if: runner.os != 'Windows'
+      run: |
+        sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Install chezmoi (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        winget install --id twpayne.chezmoi --accept-source-agreements --accept-package-agreements
+        $wingetPath = "$env:LOCALAPPDATA\Microsoft\WinGet\Links"
+        Write-Host "Adding $wingetPath to PATH"
+        echo "$wingetPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Initialize and Apply Dotfiles (Unix)
+      if: runner.os != 'Windows'
+      run: |
+        # Pre-seed machine_type for non-interactive CI.
+        mkdir -p "$HOME/.config/chezmoi"
+        printf '[data]\n    machine_type = "personal"\n' > "$HOME/.config/chezmoi/chezmoi.toml"
+
+        echo "Starting Chezmoi Apply (fast CI mode — DOTFILES_SKIP_INSTALL=1)..."
+        time chezmoi init --apply --source . --verbose
+
+    - name: Initialize and Apply Dotfiles (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path "$HOME\.config\chezmoi" -Force | Out-Null
+        @"
+        [data]
+            machine_type = "personal"
+        "@ | Out-File -FilePath "$HOME\.config\chezmoi\chezmoi.toml" -Encoding utf8
+
+        Write-Host "Starting Chezmoi Apply (fast CI mode - DOTFILES_SKIP_INSTALL=1)..."
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        chezmoi init --apply --source . --verbose
+        $stopwatch.Stop()
+        Write-Host "Installation took $($stopwatch.Elapsed.TotalSeconds) seconds"
+
+    - name: Run Validation Script (Unix)
+      if: runner.os != 'Windows'
+      run: |
+        chmod +x scripts/validate-installation.sh
+        ./scripts/validate-installation.sh
+
+    - name: Run Validation Script (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        & scripts/validate-installation-windows.ps1
 
   test-install:
     name: Test Install on ${{ matrix.os }}

--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -5,6 +5,11 @@
 
 set -e
 
+{{- if eq (env "DOTFILES_SKIP_INSTALL") "1" }}
+echo "DOTFILES_SKIP_INSTALL=1 — skipping brew bundle install (fast CI mode)"
+exit 0
+{{- end }}
+
 case "$(uname -s)" in
   Darwin*)
     # Ensure Homebrew is in PATH

--- a/home/run_once_before_install-packages.sh.tmpl
+++ b/home/run_once_before_install-packages.sh.tmpl
@@ -6,6 +6,11 @@ if [ "${RUNNER_DEBUG}" = "1" ]; then
     set -x
 fi
 
+{{- if eq (env "DOTFILES_SKIP_INSTALL") "1" }}
+echo "DOTFILES_SKIP_INSTALL=1 — skipping package install (fast CI mode)"
+exit 0
+{{- end }}
+
 case "$(uname -s)" in
   Linux*)
     echo "Linux detected"

--- a/home/run_once_install-packages-windows.ps1.tmpl
+++ b/home/run_once_install-packages-windows.ps1.tmpl
@@ -54,6 +54,10 @@ $successCount = 0
 $failureCount = 0
 $skippedCount = 0
 
+{{- if eq (env "DOTFILES_SKIP_INSTALL") "1" }}
+Write-Host "DOTFILES_SKIP_INSTALL=1 — skipping winget install loop (fast CI mode)"
+Write-Host "Registry tweaks and verification below will still run."
+{{- else }}
 foreach ($package in $packages) {
     Write-Host "Installing $package..." -ForegroundColor Cyan
 
@@ -86,6 +90,7 @@ foreach ($package in $packages) {
         $failureCount++
     }
 }
+{{- end }}
 
 Write-Host ""
 Write-Host "Installation Summary:" -ForegroundColor Cyan

--- a/home/run_onchange_after_install-cship.sh.tmpl
+++ b/home/run_onchange_after_install-cship.sh.tmpl
@@ -14,6 +14,11 @@
 
 set -e
 
+{{ if eq (env "DOTFILES_SKIP_INSTALL") "1" }}
+echo "DOTFILES_SKIP_INSTALL=1 — skipping cship install (fast CI mode)"
+exit 0
+{{ end }}
+
 CSHIP_COMMIT="1e5940e2a051288107f729ca43f912c8db41bae1"
 
 # Ensure cargo is available

--- a/home/run_onchange_install-ubuntu-packages.sh.tmpl
+++ b/home/run_onchange_install-ubuntu-packages.sh.tmpl
@@ -6,6 +6,11 @@
 
 set -e
 
+# {{ if eq (env "DOTFILES_SKIP_INSTALL") "1" }}
+echo "DOTFILES_SKIP_INSTALL=1 — skipping apt package install (fast CI mode)"
+exit 0
+# {{ end }}
+
 case "$(uname -s)" in
   Linux*)
     echo "Linux detected - installing packages from ubuntu_pkglist..."

--- a/scripts/validate-installation-windows.ps1
+++ b/scripts/validate-installation-windows.ps1
@@ -33,13 +33,22 @@ Write-Host ""
 
 $script:FailedTests = 0
 $script:PassedTests = 0
+$script:SkippedTests = 0
+
+# Fast CI mode: when set, package-dependent checks are skipped rather than
+# hard-failing. File-existence and registry checks still run.
+$FastMode = ($env:DOTFILES_SKIP_INSTALL -eq "1")
+if ($FastMode) {
+    Write-Host "Fast CI mode (DOTFILES_SKIP_INSTALL=1) - package-dependent checks will be skipped" -ForegroundColor Yellow
+    Write-Host ""
+}
 
 function Test-Validation {
     param(
         [string]$Description,
         [scriptblock]$TestCommand
     )
-    
+
     try {
         $result = & $TestCommand
         if ($result -or $LASTEXITCODE -eq 0) {
@@ -59,6 +68,23 @@ function Test-Validation {
         $script:FailedTests++
         return $false
     }
+}
+
+# Wrapper for package-dependent checks. In fast CI mode
+# (DOTFILES_SKIP_INSTALL=1) this logs a skip and returns without running the
+# test. Otherwise identical to Test-Validation.
+function Test-Validation-Pkg {
+    param(
+        [string]$Description,
+        [scriptblock]$TestCommand
+    )
+
+    if ($FastMode) {
+        Write-Host "[SKIP] $Description (skipped - DOTFILES_SKIP_INSTALL)" -ForegroundColor Yellow
+        $script:SkippedTests++
+        return $true
+    }
+    Test-Validation -Description $Description -TestCommand $TestCommand
 }
 
 # Validate PowerShell Configuration
@@ -84,7 +110,7 @@ Write-Host ""
 Write-Host "Validating Starship prompt..."
 Write-Host "-----------------------------------"
 
-Test-Validation "Starship is in PATH" {
+Test-Validation-Pkg "Starship is in PATH" {
     Get-Command starship -ErrorAction SilentlyContinue
 }
 
@@ -92,7 +118,7 @@ Test-Validation "Starship config exists" {
     Test-Path "$HOME\.config\starship.toml"
 }
 
-Test-Validation "Starship version can be queried" {
+Test-Validation-Pkg "Starship version can be queried" {
     starship --version | Out-Null
     $LASTEXITCODE -eq 0
 }
@@ -130,13 +156,16 @@ Test-Validation "Starship config has character customization" {
 }
 
 # Test prompt rendering
-if (Get-Command starship -ErrorAction SilentlyContinue) {
+if ($FastMode) {
+    Write-Host "[SKIP] Prompt renders in current directory (skipped - DOTFILES_SKIP_INSTALL)" -ForegroundColor Yellow
+    $script:SkippedTests++
+} elseif (Get-Command starship -ErrorAction SilentlyContinue) {
     Test-Validation "Prompt renders in current directory" {
         $prompt = starship prompt --terminal-width=80 -ErrorAction SilentlyContinue 2>&1
         -not [string]::IsNullOrWhiteSpace($prompt)
     }
 } else {
-    Write-Host "⚠ Prompt rendering test skipped (starship not in PATH)" -ForegroundColor Yellow
+    Write-Host "[WARN] Prompt rendering test skipped (starship not in PATH)" -ForegroundColor Yellow
 }
 
 # Validate Windows Terminal Configuration
@@ -169,9 +198,8 @@ $tools = @(
 )
 
 foreach ($tool in $tools) {
-    Test-Validation "$tool is installed" {
-        Get-Command $tool -ErrorAction SilentlyContinue
-    }
+    $toolName = $tool
+    Test-Validation-Pkg "$toolName is installed" ([scriptblock]::Create("Get-Command $toolName -ErrorAction SilentlyContinue"))
 }
 
 # Validate optional power user tools
@@ -187,12 +215,17 @@ Write-Host ""
 Write-Host "Validating optional tools..."
 Write-Host "-----------------------------------"
 
-foreach ($tool in $optionalTools) {
-    if (Get-Command $tool -ErrorAction SilentlyContinue) {
-        Write-Host "[PASS] $tool is installed" -ForegroundColor Green
-        $script:PassedTests++
-    } else {
-        Write-Host "[WARN] $tool is not installed (optional)" -ForegroundColor Yellow
+if ($FastMode) {
+    Write-Host "[SKIP] delta / lazygit / code / rustup / cargo optional tool checks (skipped - DOTFILES_SKIP_INSTALL)" -ForegroundColor Yellow
+    $script:SkippedTests += 5
+} else {
+    foreach ($tool in $optionalTools) {
+        if (Get-Command $tool -ErrorAction SilentlyContinue) {
+            Write-Host "[PASS] $tool is installed" -ForegroundColor Green
+            $script:PassedTests++
+        } else {
+            Write-Host "[WARN] $tool is not installed (optional)" -ForegroundColor Yellow
+        }
     }
 }
 
@@ -209,7 +242,10 @@ Test-Validation "Global gitignore exists" {
     Test-Path "$HOME\.gitignore_global"
 }
 
-if (Get-Command delta -ErrorAction SilentlyContinue) {
+if ($FastMode) {
+    Write-Host "[SKIP] Git is configured to use delta (skipped - DOTFILES_SKIP_INSTALL)" -ForegroundColor Yellow
+    $script:SkippedTests++
+} elseif (Get-Command delta -ErrorAction SilentlyContinue) {
     Test-Validation "Git is configured to use delta" {
         $pager = git config --get core.pager
         $pager -match "delta"
@@ -240,11 +276,11 @@ Write-Host ""
 Write-Host "Validating age encryption..."
 Write-Host "-----------------------------------"
 
-Test-Validation "Age is in PATH" {
+Test-Validation-Pkg "Age is in PATH" {
     Get-Command age -ErrorAction SilentlyContinue
 }
 
-Test-Validation "Age-keygen is in PATH" {
+Test-Validation-Pkg "Age-keygen is in PATH" {
     Get-Command age-keygen -ErrorAction SilentlyContinue
 }
 
@@ -296,7 +332,7 @@ Write-Host ""
 Write-Host "Validating fonts..."
 Write-Host "-----------------------------------"
 
-Test-Validation "JetBrains Mono Nerd Font is installed" {
+Test-Validation-Pkg "JetBrains Mono Nerd Font is installed" {
     # Check if font is installed in Windows
     $fontPath1 = "$env:WINDIR\Fonts\JetBrainsMonoNerdFont-Regular.ttf"
     $fontPath2 = "$env:LOCALAPPDATA\Microsoft\Windows\Fonts\JetBrainsMonoNerdFont-Regular.ttf"
@@ -309,10 +345,13 @@ Write-Host "=================================="
 Write-Host "Validation Summary"
 Write-Host "=================================="
 Write-Host "Passed: $script:PassedTests" -ForegroundColor Green
+if ($script:SkippedTests -gt 0) {
+    Write-Host "Skipped: $script:SkippedTests (DOTFILES_SKIP_INSTALL fast CI mode)" -ForegroundColor Yellow
+}
 Write-Host "Failed: $script:FailedTests" -ForegroundColor Red
 Write-Host ""
 
-$totalTests = $script:PassedTests + $script:FailedTests
+$totalTests = $script:PassedTests + $script:FailedTests + $script:SkippedTests
 $percentPassed = if ($totalTests -gt 0) { [math]::Round(($script:PassedTests / $totalTests) * 100, 2) } else { 0 }
 Write-Host "Success Rate: $percentPassed%" -ForegroundColor $(if ($percentPassed -ge 80) { "Green" } elseif ($percentPassed -ge 50) { "Yellow" } else { "Red" })
 Write-Host ""
@@ -322,6 +361,7 @@ $countsFile = "$env:TEMP\validation_counts.txt"
 @"
 PASSED_TESTS=$($script:PassedTests)
 FAILED_TESTS=$($script:FailedTests)
+SKIPPED_TESTS=$($script:SkippedTests)
 TOTAL_TESTS=$totalTests
 "@ | Out-File -FilePath $countsFile -Encoding utf8
 Write-Verbose "Test counts written to $countsFile"

--- a/scripts/validate-installation.sh
+++ b/scripts/validate-installation.sh
@@ -25,17 +25,26 @@ NC='\033[0m' # No Color
 FAILED_TESTS=0
 PASSED_TESTS=0
 WARNED_TESTS=0
+SKIPPED_TESTS=0
+
+# Fast CI mode: when set, package-dependent checks are skipped rather than
+# hard-failing. File-existence checks (chezmoi-deployed configs) still run.
+FAST_MODE="${DOTFILES_SKIP_INSTALL:-0}"
+if [ "$FAST_MODE" = "1" ]; then
+    echo -e "${YELLOW}Fast CI mode (DOTFILES_SKIP_INSTALL=1) — package-dependent checks will be skipped${NC}"
+    echo ""
+fi
 
 validate_test() {
     local description=$1
     local test_command=$2
     local output
-    
+
     # Run the test command and capture both stdout and stderr
     # We use eval to execute the command string properly
     output=$(eval "$test_command" 2>&1)
     local exit_code=$?
-    
+
     if [ $exit_code -eq 0 ]; then
         echo -e "${GREEN}✓${NC} $description"
         ((PASSED_TESTS++))
@@ -49,6 +58,18 @@ validate_test() {
         ((FAILED_TESTS++))
         return 1
     fi
+}
+
+# Wrapper for package-dependent checks. In fast CI mode (DOTFILES_SKIP_INSTALL=1)
+# this logs a skip and returns 0 without running the test. Otherwise identical
+# to validate_test.
+validate_test_pkg() {
+    if [ "$FAST_MODE" = "1" ]; then
+        echo -e "${YELLOW}⊘${NC} $1 (skipped — DOTFILES_SKIP_INSTALL)"
+        ((SKIPPED_TESTS++))
+        return 0
+    fi
+    validate_test "$@"
 }
 
 echo "Validating shell configuration..."
@@ -66,7 +87,7 @@ else
     validate_test "Zsh is the default shell (\$SHELL)" "[ \"\$SHELL\" = \"/bin/zsh\" ] || [ \"\$SHELL\" = \"/usr/bin/zsh\" ] || [ \"\$SHELL\" = \"$(command -v zsh)\" ] || [ \"\$SHELL\" = \"/usr/local/bin/zsh\" ] || [ \"\$SHELL\" = \"/opt/homebrew/bin/zsh\" ]"
 fi
 
-validate_test "Oh My Zsh is loaded" "[ -n \"\$ZSH\" ] || [ -d \"\$HOME/.oh-my-zsh\" ]"
+validate_test_pkg "Oh My Zsh is loaded" "[ -n \"\$ZSH\" ] || [ -d \"\$HOME/.oh-my-zsh\" ]"
 # Note: $ZSH env var is loaded effectively when .zshrc is sourced. 
 # validation script runs in bash, so $ZSH won't be set from the current shell environment
 # unless we source .zshrc (which we can't easily do from bash).
@@ -75,16 +96,16 @@ validate_test "Oh My Zsh is loaded" "[ -n \"\$ZSH\" ] || [ -d \"\$HOME/.oh-my-zs
 echo ""
 echo "Validating Starship prompt..."
 echo "-----------------------------------"
-validate_test "Starship is in PATH" "command -v starship"
+validate_test_pkg "Starship is in PATH" "command -v starship"
 validate_test "Starship config exists" "[ -f \"\$HOME/.config/starship.toml\" ]"
-validate_test "Starship version can be queried" "starship --version"
+validate_test_pkg "Starship version can be queried" "starship --version"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
     # Check for the macOS symbol () which is specific to our custom config
-    validate_test "Starship prompt uses custom config" "starship prompt | grep -q ''"
+    validate_test_pkg "Starship prompt uses custom config" "starship prompt | grep -q ''"
 elif [[ "$(uname -s)" == "Linux" ]]; then
     # Check for Ubuntu () or generic Linux () symbol
-    validate_test "Starship prompt uses custom config" "starship prompt | grep -q -E '|'"
+    validate_test_pkg "Starship prompt uses custom config" "starship prompt | grep -q -E '|'"
 fi
 
 # Verify Starship is actually loaded in the Zsh prompt
@@ -98,7 +119,7 @@ elif [[ "$(uname -s)" == "Linux" ]]; then
     script -q -c "env VSCODE_COPILOT_CHAT_TERMINAL='' zsh -ic 'echo \"PROMPT=\$PROMPT\"'" "$PROMPT_CHECK_FILE" >/dev/null 2>&1
 fi
 
-validate_test "Starship is hooked into Zsh PROMPT" "grep -F 'starship prompt' \"$PROMPT_CHECK_FILE\""
+validate_test_pkg "Starship is hooked into Zsh PROMPT" "grep -F 'starship prompt' \"$PROMPT_CHECK_FILE\""
 rm -f "$PROMPT_CHECK_FILE"
 
 # Additional prompt functionality tests (T024)
@@ -117,12 +138,12 @@ mkdir -p "$PROMPT_TEST_DIR"
 cd "$PROMPT_TEST_DIR" || exit 1
 
 # Test basic directory prompt
-validate_test "Prompt renders in non-git directory" "starship prompt --terminal-width=80 2>/dev/null | grep -q '.'"
+validate_test_pkg "Prompt renders in non-git directory" "starship prompt --terminal-width=80 2>/dev/null | grep -q '.'"
 
 # Test git directory prompt
 if command -v git >/dev/null 2>&1; then
     git init >/dev/null 2>&1
-    validate_test "Prompt renders in git repository" "starship prompt --terminal-width=80 2>/dev/null | grep -q '.'"
+    validate_test_pkg "Prompt renders in git repository" "starship prompt --terminal-width=80 2>/dev/null | grep -q '.'"
 fi
 
 cd - >/dev/null 2>&1 || exit 1
@@ -134,7 +155,7 @@ echo "-----------------------------------"
 # Check if xterm-ghostty terminfo is available (important for SSH from Ghostty)
 # We test this even if NOT currently running in Ghostty, as it's a system requirement 
 # for seamless SSH access into this machine.
-validate_test "xterm-ghostty terminfo is installed" "infocmp xterm-ghostty >/dev/null 2>&1"
+validate_test_pkg "xterm-ghostty terminfo is installed" "infocmp xterm-ghostty >/dev/null 2>&1"
 
 if command -v pwsh >/dev/null 2>&1; then
     echo ""
@@ -155,9 +176,9 @@ if command -v pwsh >/dev/null 2>&1; then
     fi
     
     if [[ "$(uname -s)" == "Darwin" ]]; then
-         validate_test "PowerShell prompt renders Starship symbol" "grep -q '' \"$PWSH_CHECK_FILE\""
+         validate_test_pkg "PowerShell prompt renders Starship symbol" "grep -q '' \"$PWSH_CHECK_FILE\""
     elif [[ "$(uname -s)" == "Linux" ]]; then
-         validate_test "PowerShell prompt renders Starship symbol" "grep -q -E '|' \"$PWSH_CHECK_FILE\""
+         validate_test_pkg "PowerShell prompt renders Starship symbol" "grep -q -E '|' \"$PWSH_CHECK_FILE\""
     fi
     rm -f "$PWSH_CHECK_FILE"
 fi
@@ -167,69 +188,76 @@ fi
 echo ""
 echo "Validating tools..."
 echo "-----------------------------------"
-validate_test "Git is installed" "command -v git"
-validate_test "Age is installed" "command -v age"
+validate_test_pkg "Git is installed" "command -v git"
+validate_test_pkg "Age is installed" "command -v age"
 
 # Phase 9 tools
 validate_test "Git config exists" "[ -f \"\$HOME/.gitconfig\" ]"
 validate_test "Global gitignore exists" "[ -f \"\$HOME/.gitignore_global\" ]"
 validate_test "Tmux config exists" "[ -f \"\$HOME/.tmux.conf\" ]"
 
-# Check for tools that should be installed via Brewfile or apt packages
-if command -v delta >/dev/null 2>&1; then
-    echo -e "${GREEN}✓${NC} git-delta is installed"
-    ((PASSED_TESTS++))
-    validate_test "Git is configured to use delta" "git config --get core.pager | grep -q delta"
+# Check for tools that should be installed via Brewfile or apt packages.
+# In fast CI mode (DOTFILES_SKIP_INSTALL=1), these binary presence checks
+# are skipped — the packages haven't been installed.
+if [ "$FAST_MODE" = "1" ]; then
+    echo -e "${YELLOW}⊘${NC} git-delta / lazygit / tmux / rustup / ghostty binary checks (skipped — DOTFILES_SKIP_INSTALL)"
+    SKIPPED_TESTS=$((SKIPPED_TESTS + 5))
 else
-    echo -e "${RED}✗${NC} git-delta is installed"
-    ((FAILED_TESTS++))
-fi
-
-if command -v lazygit >/dev/null 2>&1; then
-    echo -e "${GREEN}✓${NC} lazygit is installed"
-    ((PASSED_TESTS++))
-    validate_test "Lazygit config exists" "[ -f \"\$HOME/.config/lazygit/config.yml\" ]"
-else
-    echo -e "${RED}✗${NC} lazygit is installed"
-    ((FAILED_TESTS++))
-fi
-
-if command -v tmux >/dev/null 2>&1; then
-    echo -e "${GREEN}✓${NC} tmux is installed"
-    ((PASSED_TESTS++))
-else
-    echo -e "${RED}✗${NC} tmux is installed"
-    ((FAILED_TESTS++))
-fi
-
-if command -v rustup >/dev/null 2>&1; then
-    echo -e "${GREEN}✓${NC} rustup is installed"
-    ((PASSED_TESTS++))
-    validate_test "Cargo is installed" "command -v cargo"
-    validate_test "Rust stable toolchain is installed" "rustup toolchain list | grep -q stable"
-else
-    echo -e "${RED}✗${NC} rustup is installed"
-    ((FAILED_TESTS++))
-fi
-
-if [[ "$(uname -s)" == "Darwin" ]]; then
-   # Ghostty is only installed on macOS/Windows in this setup
-   if command -v ghostty >/dev/null 2>&1; then
-        echo -e "${GREEN}✓${NC} Ghostty is installed"
+    if command -v delta >/dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} git-delta is installed"
         ((PASSED_TESTS++))
-   else
-        # Ghostty might be a cask or app, command -v might not find it if not in path
-        # But for this test, let's assume valid if strictly found or if strictly required.
-        # Given it is installed via brew, it might be available.
-        # However, checking for the app bundle might be safer if command missing.
-        if [ -d "/Applications/Ghostty.app" ] || [ -d "$HOME/Applications/Ghostty.app" ]; then
-             echo -e "${GREEN}✓${NC} Ghostty.app found"
-             ((PASSED_TESTS++))
-        else
-             echo -e "${RED}✗${NC} Ghostty is installed"
-             ((FAILED_TESTS++))
-        fi
-   fi
+        validate_test "Git is configured to use delta" "git config --get core.pager | grep -q delta"
+    else
+        echo -e "${RED}✗${NC} git-delta is installed"
+        ((FAILED_TESTS++))
+    fi
+
+    if command -v lazygit >/dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} lazygit is installed"
+        ((PASSED_TESTS++))
+        validate_test "Lazygit config exists" "[ -f \"\$HOME/.config/lazygit/config.yml\" ]"
+    else
+        echo -e "${RED}✗${NC} lazygit is installed"
+        ((FAILED_TESTS++))
+    fi
+
+    if command -v tmux >/dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} tmux is installed"
+        ((PASSED_TESTS++))
+    else
+        echo -e "${RED}✗${NC} tmux is installed"
+        ((FAILED_TESTS++))
+    fi
+
+    if command -v rustup >/dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} rustup is installed"
+        ((PASSED_TESTS++))
+        validate_test "Cargo is installed" "command -v cargo"
+        validate_test "Rust stable toolchain is installed" "rustup toolchain list | grep -q stable"
+    else
+        echo -e "${RED}✗${NC} rustup is installed"
+        ((FAILED_TESTS++))
+    fi
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+       # Ghostty is only installed on macOS/Windows in this setup
+       if command -v ghostty >/dev/null 2>&1; then
+            echo -e "${GREEN}✓${NC} Ghostty is installed"
+            ((PASSED_TESTS++))
+       else
+            # Ghostty might be a cask or app, command -v might not find it if not in path
+            # But for this test, let's assume valid if strictly found or if strictly required.
+            # Given it is installed via brew, it might be available.
+            # However, checking for the app bundle might be safer if command missing.
+            if [ -d "/Applications/Ghostty.app" ] || [ -d "$HOME/Applications/Ghostty.app" ]; then
+                 echo -e "${GREEN}✓${NC} Ghostty.app found"
+                 ((PASSED_TESTS++))
+            else
+                 echo -e "${RED}✗${NC} Ghostty is installed"
+                 ((FAILED_TESTS++))
+            fi
+       fi
+    fi
 fi
 
 echo ""
@@ -237,8 +265,8 @@ echo "Validating Zsh plugins..."
 echo "-----------------------------------"
 # Check custom plugins
 ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
-validate_test "zsh-autosuggestions installed" "[ -d \"$ZSH_CUSTOM/plugins/zsh-autosuggestions\" ]"
-validate_test "zsh-syntax-highlighting installed" "[ -d \"$ZSH_CUSTOM/plugins/zsh-syntax-highlighting\" ]"
+validate_test_pkg "zsh-autosuggestions installed" "[ -d \"$ZSH_CUSTOM/plugins/zsh-autosuggestions\" ]"
+validate_test_pkg "zsh-syntax-highlighting installed" "[ -d \"$ZSH_CUSTOM/plugins/zsh-syntax-highlighting\" ]"
 
 echo ""
 echo "Validating chezmoi..."
@@ -250,22 +278,25 @@ validate_test "Chezmoi can list managed files" "chezmoi managed"
 echo ""
 echo "Validating age encryption..."
 echo "-----------------------------------"
-validate_test "Age is in PATH" "command -v age"
-validate_test "Age keygen is in PATH" "command -v age-keygen"
+validate_test_pkg "Age is in PATH" "command -v age"
+validate_test_pkg "Age keygen is in PATH" "command -v age-keygen"
 
 # macOS-specific validations
 if [[ "$(uname -s)" == "Darwin" ]]; then
     echo ""
     echo "Validating macOS-specific tools..."
     echo "-----------------------------------"
-    validate_test "Homebrew is in PATH" "command -v brew"
-    validate_test "Ghostty is installed" "[ -d \"/Applications/Ghostty.app\" ] || command -v ghostty"
+    validate_test_pkg "Homebrew is in PATH" "command -v brew"
+    validate_test_pkg "Ghostty is installed" "[ -d \"/Applications/Ghostty.app\" ] || command -v ghostty"
     validate_test "Brewfile exists" "[ -f \"\$HOME/Brewfile\" ]"
-    
+
     # Check for Nerd Font installation (macOS only via Brewfile)
     # Font cask installs are flaky on GitHub Actions runners (headless, no GUI),
-    # so downgrade to a warning in CI to avoid blocking the entire pipeline.
-    if fc-list | grep -qi "JetBrainsMono Nerd"; then
+    # and packages aren't installed at all in fast CI mode — skip in both cases.
+    if [ "$FAST_MODE" = "1" ]; then
+        echo -e "${YELLOW}⊘${NC} JetBrains Mono Nerd Font (skipped — DOTFILES_SKIP_INSTALL)"
+        ((SKIPPED_TESTS++))
+    elif fc-list | grep -qi "JetBrainsMono Nerd"; then
         echo -e "${GREEN}✓${NC} JetBrains Mono Nerd Font is installed"
         ((PASSED_TESTS++))
     elif [ "${CI:-}" = "true" ]; then
@@ -298,6 +329,9 @@ echo "================================"
 echo "Validation Summary"
 echo "================================"
 echo -e "${GREEN}Passed: $PASSED_TESTS${NC}"
+if [ "$SKIPPED_TESTS" -gt 0 ]; then
+    echo -e "${YELLOW}Skipped: $SKIPPED_TESTS${NC} (DOTFILES_SKIP_INSTALL fast CI mode)"
+fi
 if [ "$WARNED_TESTS" -gt 0 ]; then
     echo -e "${YELLOW}Warned: $WARNED_TESTS${NC}"
 fi
@@ -305,11 +339,14 @@ echo -e "${RED}Failed: $FAILED_TESTS${NC}"
 echo ""
 
 # Save counts for CI summary if running in CI environment
-echo "PASSED_TESTS=$PASSED_TESTS" > /tmp/validation_counts.txt
-echo "FAILED_TESTS=$FAILED_TESTS" >> /tmp/validation_counts.txt
-echo "WARNED_TESTS=$WARNED_TESTS" >> /tmp/validation_counts.txt
-TOTAL_TESTS=$((PASSED_TESTS + FAILED_TESTS + WARNED_TESTS))
-echo "TOTAL_TESTS=$TOTAL_TESTS" >> /tmp/validation_counts.txt
+TOTAL_TESTS=$((PASSED_TESTS + FAILED_TESTS + WARNED_TESTS + SKIPPED_TESTS))
+{
+    echo "PASSED_TESTS=$PASSED_TESTS"
+    echo "FAILED_TESTS=$FAILED_TESTS"
+    echo "WARNED_TESTS=$WARNED_TESTS"
+    echo "SKIPPED_TESTS=$SKIPPED_TESTS"
+    echo "TOTAL_TESTS=$TOTAL_TESTS"
+} > /tmp/validation_counts.txt
 
 if [ $FAILED_TESTS -eq 0 ]; then
     echo -e "${GREEN}All validations passed! Your dotfiles are properly installed.${NC}"

--- a/scripts/validate-installation.sh
+++ b/scripts/validate-installation.sh
@@ -74,8 +74,14 @@ validate_test_pkg() {
 
 echo "Validating shell configuration..."
 echo "-----------------------------------"
-# Check using getent/dscl if possible, fallback to ENV check but warn it might be stale
-if command -v getent >/dev/null 2>&1; then
+# Check using getent/dscl if possible, fallback to ENV check but warn it might be stale.
+# In fast CI mode, the install script that installs zsh and runs chsh is skipped,
+# so the login shell is still the runner default (bash) — skip the test rather
+# than hard-fail.
+if [ "$FAST_MODE" = "1" ]; then
+    echo -e "${YELLOW}⊘${NC} Zsh is the configured shell (skipped — DOTFILES_SKIP_INSTALL)"
+    ((SKIPPED_TESTS++))
+elif command -v getent >/dev/null 2>&1; then
     USER_SHELL=$(getent passwd "$USER" | cut -d: -f7)
     echo "Detected shell via getent: $USER_SHELL"
     validate_test "Zsh is the configured shell (getent)" "[ \"$USER_SHELL\" = \"$(command -v zsh)\" ] || [ \"$USER_SHELL\" = \"/bin/zsh\" ] || [ \"$USER_SHELL\" = \"/usr/bin/zsh\" ] || [ \"$USER_SHELL\" = \"/usr/local/bin/zsh\" ] || [ \"$USER_SHELL\" = \"/opt/homebrew/bin/zsh\" ]"


### PR DESCRIPTION
## Summary

Replaces the `test-install-pr` stub (currently just `echo "Skipping full install test on PR"`) with a real fast-CI variant that runs `chezmoi init --apply` on all 3 OSes but **skips the expensive package installs** via a new `DOTFILES_SKIP_INSTALL=1` env var.

**Target runtime: ~3–5 min per OS** vs ~22 min for the full `test-install` job (which still runs unchanged on push-to-main).

## Why

PR #124 landed a broken `run_once_remove-claude-code-cask.sh` whose runtime `case "$(uname -s)"` Darwin guard never fired on Windows — `CreateProcess` rejects POSIX-shebang scripts with `%1 is not a valid Win32 application` before the guard can run. The PR-stub CI couldn't catch it because **it never actually ran `chezmoi init --apply`**. The full `test-install` on main caught it only post-merge, requiring the PR #127 hotfix.

This fast variant would have caught that exact class of bug pre-merge.

## Architecture

### Template-time gate in 5 expensive scripts

All 5 expensive install scripts are already `.tmpl` templates, so they gain a template-time conditional that renders an early `exit 0` stub when `DOTFILES_SKIP_INSTALL=1`:

- `home/run_once_before_install-packages.sh.tmpl` (brew/apt base + Rust + Starship + OMZ + nano build — **5-15 min**)
- `home/run_once_after_install-brewfile.sh.tmpl` (`brew bundle install` — **2-25 min**)
- `home/run_once_install-packages-windows.ps1.tmpl` (winget install loop — gates **only** the loop; registry tweaks for Long Paths + Developer Mode still run — **5-15 min**)
- `home/run_onchange_install-ubuntu-packages.sh.tmpl` (apt + lazygit + pwsh + uv — **3-10 min**)
- `home/run_onchange_after_install-cship.sh.tmpl` (`cargo install` cship — **1-3 min**)

Pattern (shell scripts):

```sh
#!/bin/sh
set -e

{{- if eq (env "DOTFILES_SKIP_INSTALL") "1" }}
echo "DOTFILES_SKIP_INSTALL=1 — skipping package install (fast CI mode)"
exit 0
{{- end }}

# ... existing body (unreached in fast mode) ...
```

### Validation script refactor

Both validation scripts gain a wrapper:

- `scripts/validate-installation.sh` → `validate_test_pkg` wrapper skips package-dependent checks when `DOTFILES_SKIP_INSTALL=1`
- `scripts/validate-installation-windows.ps1` → `Test-Validation-Pkg` does the same

**Rule**: package-dependent binary checks (`command -v delta`, starship prompt rendering, Oh My Zsh plugin dirs, etc.) become **skipped** in fast mode, NOT soft-warned — soft-warns obscure real failures. **File-existence checks stay as hard failures** because chezmoi-deployed configs are exactly what fast CI is validating.

### New CI job

Replaces `test-install-pr` stub at `.github/workflows/ci.yml:55-64`. Key design:

- **Same check name** `Test Install on ${{ matrix.os }}` — branch protection required-check rules are satisfied by either variant without reconfiguration
- `runs-on: ${{ matrix.os }}` — real OS, not ubuntu-only
- `env: DOTFILES_SKIP_INSTALL: '1'`
- **No strip-pre-installed-tools step** (saves ~10 min on macOS)
- **No disk-space telemetry or zsh-startup benchmark** (belong on the full job)
- Steps: checkout → install chezmoi → pre-seed chezmoi.toml → `chezmoi init --apply --source . --verbose` → validation script

The existing full `test-install` job at lines 66+ is unchanged — still runs on push-to-main, still exercises the full package install path.

## What this fast job catches

- Shebang/exec issues (the PR #124 root cause)
- Chezmoi template rendering bugs (any `{{ }}` syntax error)
- `.chezmoiignore` misconfigurations (wrong file gated on wrong OS)
- `run_once_*` script logic errors that fire at apply time
- Validation script bugs
- Breaking changes in chezmoi-deployed file paths

## What this fast job does NOT catch

- Package install script bugs (still caught by the full `test-install` on main)
- Brewfile / winget package list changes (full job still runs them on main)
- Anything requiring actual installed binaries to test (covered by full job)

## Test plan

- [x] `shellcheck` clean on `scripts/validate-installation.sh` (the one non-`.tmpl` shell file)
- [x] `actionlint` clean on `.github/workflows/ci.yml`
- [x] `pwsh` parse-check clean on `scripts/validate-installation-windows.ps1`
- [x] `chezmoi execute-template` renders each modified template in both normal and fast modes — fast mode produces `exit 0` before the expensive body, normal mode is unchanged
- [x] Local `chezmoi init --apply --source . --dry-run --verbose` with `DOTFILES_SKIP_INSTALL=1` — exit 0, 3 template gates fire on darwin (before-install, brewfile, cship; ubuntu/windows scripts are chezmoiignored on darwin)
- [x] Local validation script smoke test with `DOTFILES_SKIP_INSTALL=1` — **16 passed, 23 skipped, 0 failed**
- [ ] CI lint checks (shellcheck / markdown-lint / actionlint)
- [ ] **The fast-CI job itself runs on this PR** — this is the first real exercise. Target <5 min per OS. If it passes, the feature works; if it fails, we iterate
- [ ] Post-merge: full `test-install` on main is still green (confirms normal-mode template rendering is unbroken)

## Files NOT modified (and why)

- `home/run_once_install-vscode-extensions.sh` and `.ps1.tmpl` — self-skip when `code` binary is absent (which it is in fast CI)
- `home/run_once_macos_defaults.sh` — cheap (`defaults write` + `killall`), already Darwin-gated
- `home/run_once_after_setup-secrets.sh.tmpl` — already state-gates on `command -v bw` + `[ ! -t 0 ]`
- `home/run_once_configure-wsl.sh.tmpl` — self-gates on `/proc/version` containing `microsoft|wsl`
- `home/run_once_setup-windows-environment.ps1.tmpl` — cheap env var setup
- `home/run_once_remove-claude-code-cask.sh` — already `.chezmoiignore`d on non-darwin (PR #127); on darwin CI where brew is uninstalled, `command -v brew` returns false → early exit
- `home/run_onchange_setup-claude.sh` — self-gates on `command -v claude`

Closes dotfiles-ayz.

---

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;