### PR TITLE
fix(ci): tighten /usr/share/zsh perms before zsh startup measurement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,12 @@ jobs:
     - name: Measure Zsh Startup Time (Unix)
       if: runner.os != 'Windows'
       run: |
+        # ubuntu-latest ships /usr/share/zsh as world-writable (drwxrwxrwx+),
+        # which makes oh-my-zsh's compinit refuse to load completions and exit 1.
+        # Tighten perms before measuring. See beads dotfiles-oz3.
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          sudo chmod -R go-w /usr/share/zsh
+        fi
         zsh -i -c exit  # warm run
         ZSH_STARTUP=$( { time zsh -i -c exit; } 2>&1 )
         echo "$ZSH_STARTUP"


### PR DESCRIPTION
## Summary

CI has been red on every push to `main` since 2026-04-17. The `Measure Zsh Startup Time (Unix)` step on `ubuntu-latest` fails because the runner image now ships `/usr/share/zsh` as world-writable (`drwxrwxrwx+`, ACLs present). oh-my-zsh's `compinit` refuses to load completions from insecure directories and exits 1.

Fix: `sudo chmod -R go-w /usr/share/zsh` on Linux runners before the measurement. Targeted to the actual permission anomaly rather than disabling the security check (`ZSH_DISABLE_COMPFIX`) wholesale.

Other CI jobs (ShellCheck, Markdown Lint, Action Lint, macOS/Windows test-install) were unaffected.

Closes beads `dotfiles-oz3`.

## Test plan

- [ ] CI: `Measure Zsh Startup Time (Unix)` step passes on ubuntu-latest
- [ ] macOS / Windows test-install jobs unaffected (the `RUNNER_OS = Linux` guard skips them)
- [ ] Reported zsh startup time is non-zero (sanity check that `time zsh -i -c exit` ran successfully)
