### PR TITLE
fix(ci): remove fzf from apt package list (Brewfile is canonical, has modern version)

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -18,7 +18,6 @@
             packages = [
                 "bat",
                 "curl",
-                "fzf",
                 "git",
                 "git-delta",
                 "jq",
@@ -33,7 +32,6 @@
             packages = [
                 "bat",
                 "curl",
-                "fzf",
                 "git",
                 "git-delta",
                 "jq",
@@ -47,7 +45,6 @@
             packages = [
                 "bat",
                 "curl",
-                "fzf",
                 "git",
                 "git-delta",
                 "jq",


### PR DESCRIPTION
## Summary

Test Install on `ubuntu-latest` fails on every push to `main` with `unknown option: --zsh` from `~/.zshrc`'s `eval "$(fzf --zsh)"`.

**Cause**: `home/.chezmoi.toml.tmpl` listed `fzf` in `data.packages.apt` for all three machine types. `apt` installs fzf 0.44.1 from Ubuntu noble repos to `/usr/bin/fzf` — predates the `--zsh` flag (added in fzf 0.48.0, Feb 2024). `Brewfile.tmpl` ALSO lists fzf and `brew bundle` installs the modern version (0.71.0), but `/usr/bin` is earlier on `PATH` than linuxbrew, so the stale apt copy wins.

**Fix**: drop `fzf` from all three apt arrays. Brewfile is the canonical source.

## Worth a follow-up audit

There are probably other duplicates between apt and Brewfile (`bat`, `jq`, `git-delta` jump out at me). Each is a potential version-drift hazard with this exact failure shape. A scripted check (`comm -12 <(sort apt-list) <(sort brew-list)`) would surface them all. Captured in the bead for later.

Closes beads `dotfiles-5dn`.

## Test plan

- [ ] CI: shellcheck, markdownlint, actionlint pass
- [ ] **Test Install on ubuntu-latest passes**, including `Measure Zsh Startup Time` step
- [ ] After merge, `eval "$(fzf --zsh)"` in `~/.zshrc` succeeds (brew's modern fzf wins on PATH because apt's old one is no longer installed)
