### PR TITLE
fix(ci): make 'Measure Zsh Startup Time' step tolerant + non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,18 +263,23 @@ jobs:
         ./scripts/validate-installation.sh
 
     - name: Measure Zsh Startup Time (Unix)
+      # Informational only — feeds the GITHUB_STEP_SUMMARY table.
+      # Never block the job on this measurement.
+      continue-on-error: true
       if: runner.os != 'Windows'
       run: |
-        # ubuntu-latest ships /usr/share/zsh as world-writable (drwxrwxrwx+),
-        # which makes oh-my-zsh's compinit refuse to load completions and exit 1.
-        # Tighten perms before measuring. See beads dotfiles-oz3.
-        if [ "$RUNNER_OS" = "Linux" ]; then
-          sudo chmod -R go-w /usr/share/zsh
+        set -x
+        # Some ubuntu-latest runner images ship /usr/share/zsh as world-writable
+        # (drwxrwxrwx+), which makes oh-my-zsh's compinit refuse to load
+        # completions. Tighten perms before measuring. See beads dotfiles-oz3.
+        if [ "$RUNNER_OS" = "Linux" ] && [ -d /usr/share/zsh ]; then
+          sudo chmod -R go-w /usr/share/zsh || true
         fi
-        zsh -i -c exit  # warm run
-        ZSH_STARTUP=$( { time zsh -i -c exit; } 2>&1 )
+        # Warm + timed run. Tolerate any failure — see continue-on-error above.
+        zsh -i -c exit 2>&1 || true
+        ZSH_STARTUP=$( { time zsh -i -c exit; } 2>&1 || true )
         echo "$ZSH_STARTUP"
-        REAL_TIME=$(echo "$ZSH_STARTUP" | grep '^real' | awk '{print $2}')
+        REAL_TIME=$(echo "$ZSH_STARTUP" | grep '^real' | awk '{print $2}' || echo "unknown")
         echo "ZSH_STARTUP_TIME=$REAL_TIME" > /tmp/zsh_startup.txt
 
     - name: Run Validation Script (Windows)


### PR DESCRIPTION
## Summary

The step's only consumer is a single-row markdown summary in `GITHUB_STEP_SUMMARY` (informational). It shouldn't fail the job, ever.

Latest failure exited 1 in 1 second with **no diagnostic output** — no chmod error, no zsh stderr, no grep failure visible. Cause is opaque because the step ran under `bash -e` with no tracing. PR #149's removal of fzf from apt eliminated the previous failure mode (`unknown option: --zsh`), but main is now red for an unknown reason.

### Three changes

- **`continue-on-error: true`** at the step level — informational measurement should never block the job.
- **`set -x`** at the top of the script — future silent failures will show which command exited non-zero in the trace output.
- **Defensive `|| true` / fallback `"unknown"`** on each command that could fail (chmod, zsh -i, grep) — so a single hiccup doesn't take the whole step down. The summary cell will show `unknown` instead of `N/A` so you can tell *something* went wrong without it being a mystery.

Also gates the chmod on directory existence (`[ -d /usr/share/zsh ]`) so future runner images that don't have it won't trip.

Closes beads `dotfiles-c7f`.

## Test plan

- [ ] CI: shellcheck, markdownlint, actionlint pass
- [ ] **Test Install on ubuntu-latest now stays green**, even if the zsh startup step itself errors
- [ ] Step still runs and writes `/tmp/zsh_startup.txt` (with either a real time or `unknown`)
- [ ] Job summary `Zsh Startup` row populated (with the time, or `unknown` instead of `N/A`)
- [ ] Trace output (`set -x`) shows in the step log so the underlying failure mode is now visible for follow-up
