### PR TITLE
refactor(git-templates): remove beads coupling — bd manages its own hooks

### DIFF
--- a/home/dot_git-templates/hooks/_lib/dispatch.sh
+++ b/home/dot_git-templates/hooks/_lib/dispatch.sh
@@ -10,10 +10,6 @@ has_precommit() {
     [ -f "${GIT_WORK_TREE:-.}/.pre-commit-config.yaml" ]
 }
 
-has_beads() {
-    [ -d "${GIT_WORK_TREE:-.}/.beads" ]
-}
-
 # ---------------------------------------------------------------------------
 # Utility
 # ---------------------------------------------------------------------------
@@ -39,15 +35,4 @@ run_precommit() {
         return 0
     fi
     pre-commit run --hook-stage "$_stage" "$@"
-}
-
-run_beads() {
-    _hook="$1"
-    shift
-    has_beads || return 0
-    if ! command_available bd; then
-        _warn "beads config found but 'bd' is not installed"
-        return 0
-    fi
-    bd hooks run "$_hook" "$@"
 }

--- a/home/dot_git-templates/hooks/executable_post-checkout
+++ b/home/dot_git-templates/hooks/executable_post-checkout
@@ -9,5 +9,3 @@ _lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
 
 # Only run on branch checkout ($3 = "1"), not file checkout
 [ "${3:-0}" = "1" ] || exit 0
-
-run_beads post-checkout "$@"

--- a/home/dot_git-templates/hooks/executable_post-merge
+++ b/home/dot_git-templates/hooks/executable_post-merge
@@ -6,5 +6,3 @@ _lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
 [ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
 # shellcheck source=_lib/dispatch.sh
 . "$_lib"
-
-run_beads post-merge "$@"

--- a/home/dot_git-templates/hooks/executable_pre-commit
+++ b/home/dot_git-templates/hooks/executable_pre-commit
@@ -7,6 +7,4 @@ _lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
 # shellcheck source=_lib/dispatch.sh
 . "$_lib"
 
-# Beads first so its staged JSONL is included in pre-commit's lint pass
-run_beads pre-commit
 run_precommit pre-commit

--- a/home/dot_git-templates/hooks/executable_pre-push
+++ b/home/dot_git-templates/hooks/executable_pre-push
@@ -7,5 +7,4 @@ _lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
 # shellcheck source=_lib/dispatch.sh
 . "$_lib"
 
-run_beads pre-push "$@"
 run_precommit pre-push


### PR DESCRIPTION
## Why

The shared dispatch library in `~/.git-templates/hooks/_lib/dispatch.sh` defined `has_beads()` + `run_beads()`, and every hook template called `run_beads <stage>`. Two problems:

1. **Tight coupling.** Generic git-template hook routing has no business knowing about a specific tool (beads). bd v1.0+ already installs its own `<!-- BEGIN BEADS INTEGRATION -->` block into each per-repo `.beads/hooks/*` file, with timeout handling on any platform that has `timeout` on `PATH`.
2. **Double invocation + deadlock.** In a beads-enabled repo, bd's pre-commit ran twice per commit — once via dispatch's `run_beads` (no timeout wrapper) and once via bd's own BEADS INTEGRATION block (timeout-aware). The un-wrapped `run_beads` is the direct cause of the deadlock we hit during `/bd-modernize` on `pauls-blogs` (23-minute hang) and `cloud-run-overlap-ips-with-nat`. bd init holds the DB lock; `run_beads` calls `bd export` which blocks on that lock forever.

## What

- `hooks/_lib/dispatch.sh`: drop `has_beads()` and `run_beads()`
- `hooks/pre-commit`, `post-checkout`, `post-merge`, `pre-push`: drop the `run_beads <stage>` call
- Keep generic pre-commit-framework dispatch (`run_precommit`)

No beads references remain in the git-templates source tree.

## Coordinated rollout

**Do not merge this until the per-repo sweep PRs are merged.** Sequence:

1. Sweep PRs in each currently-infected repo (remove stale `run_beads <stage>` lines from its `.beads/hooks/*`): `dotfiles`, `gcp-org-management`, `paul-claw`, `paul-gledhill-dev`, `pauls-blogs`, `test-dolt`, `cloud-run-overlap-ips-with-nat`
2. Merge those
3. Merge this PR
4. `chezmoi apply` locally
5. Resume modernization rollout — `bd init` now produces clean hooks from vanilla templates

If this PR merges before the sweep, commits in the 7 infected repos fail with `run_beads: command not found` until each is swept.

## Test plan

- [x] `shellcheck` clean on all 5 touched files
- [x] No remaining beads references in `home/dot_git-templates/`
- [ ] Manual: after full rollout, run `/bd-modernize` on a fresh repo and confirm no deadlock and no `run_beads` in resulting hooks

Closes dotfiles-gum.