### PR TITLE
fix(git-templates): restore run_beads as a backward-compat no-op stub

### DIFF
--- a/home/dot_git-templates/hooks/_lib/dispatch.sh
+++ b/home/dot_git-templates/hooks/_lib/dispatch.sh
@@ -36,3 +36,45 @@ run_precommit() {
     fi
     pre-commit run --hook-stage "$_stage" "$@"
 }
+
+# run_beads: backward-compatibility stub for hooks installed before dotfiles#153
+# decoupled this library from beads.
+#
+# Since PR #153, template hooks no longer call run_beads; modern bd installs
+# its own BEADS INTEGRATION block directly into .beads/hooks/*. But .git/hooks/*
+# files are PER-CLONE artifacts copied at `git init`/`git clone` time and are
+# not updated by `chezmoi apply` — so every repo on this machine cloned before
+# 2026-04-19 still has template hooks that call `run_beads <stage>` after
+# sourcing this library. Without the function, pre-commit's `set -e` blocks
+# every commit; post-checkout/post-merge print noisy "command not found" lines.
+#
+# This stub no-ops cleanly when:
+#   - the repo has no `.beads/` directory (most non-beads repos), OR
+#   - `bd` is not installed, OR
+#   - bd's hook takes too long (covered by the same timeout escape-hatch used
+#     by bd's own integration block; treats GNU-timeout's exit 124 as "continue").
+#
+# When all three conditions are favourable it delegates to `bd hooks run`,
+# matching what the pre-#153 behaviour of this function was.
+#
+# The stub is intentionally backward-compat-only: new hooks should embed bd's
+# managed BEADS INTEGRATION block (installed by `bd hooks install`) rather than
+# rely on this dispatcher.
+run_beads() {
+    _hook="$1"
+    shift
+    [ -d "${GIT_WORK_TREE:-.}/.beads" ] || return 0
+    command_available bd || return 0
+    _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+    if command_available timeout; then
+        timeout "$_bd_timeout" bd hooks run "$_hook" "$@"
+        _rc=$?
+        if [ "$_rc" -eq 124 ]; then
+            _warn "beads hook '$_hook' timed out after ${_bd_timeout}s — continuing"
+            return 0
+        fi
+        return "$_rc"
+    else
+        bd hooks run "$_hook" "$@"
+    fi
+}


### PR DESCRIPTION
## Apology

I made a bad call during the bd-modernize rollout. When given the choice between a stub (Option A) or a full rip (Option B), I recommended B. I should have flagged the blast radius of B — which is what's now biting:

**`.git/hooks/*` files are per-clone artifacts, copied from `~/.git-templates/` at `git init`/`git clone` time. `chezmoi apply` doesn't touch them.** So every repo on this machine that was initialised before 2026-04-19 still has template hooks that call `run_beads <stage>` after sourcing this library. Once the library lacked `run_beads`, pre-commit's `set -e` started blocking every commit on non-beads repos (e.g. `automate-github`); post-checkout and post-merge print noisy errors everywhere.

No PR could have fixed this per-repo — the affected files aren't tracked. The only reliable fix is to restore the symbol centrally.

## The fix

Add `run_beads` back to `dispatch.sh` as a **no-op stub** that:

- Returns 0 cleanly when the repo has no `.beads/` — which is every currently affected repo. This is the only path that actually fires in practice.
- Returns 0 when `bd` isn't installed.
- For the theoretical edge case of a stale `.git/hooks/*` firing in a beads-enabled repo where `core.hooksPath` is unset: delegates to `bd hooks run` with the same `timeout` escape hatch bd's own v1.0.2 BEADS INTEGRATION block uses.

The decoupling intent of #153 still holds: the **template hooks themselves** (`pre-commit`, `post-checkout`, `post-merge`, `pre-push`) don't call `run_beads`. Any NEW `git init` / `git clone` after this merges produces hooks with no beads coupling. The stub exists purely to keep the install base from pre-#153 working.

## Test plan

- [x] Smoke-tested: simulated an old-shim hook in a throwaway non-beads repo. `git commit` completes cleanly with no "command not found" and no unwanted bd invocation.
- [x] `shellcheck` clean.
- [ ] After merge + `dotup`: commits in `automate-github` stop erroring; `git checkout` / `git pull` in beads repos stop printing the `run_beads` warnings.

## Alternative considered

Sweep every repo's `.git/hooks/*` via a one-shot script that re-runs `bd hooks install --beads` per repo. That would also fix the symptom, but (a) you'd have to run it on every machine, (b) it doesn't help non-beads repos at all, and (c) anyone else cloning before this change still breaks. The compat stub fixes all three.