### PR TITLE
feat(claude): parallelize /end-session Phase 1 gather via scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ Thumbs.db
 # Ignore temporary files
 temp/
 
-# Ignore downloaded binaries
-bin/
+# Ignore downloaded binaries at repo root (not nested bin/ dirs under home/)
+/bin/
 
 # Dolt database files (added by bd init)
 .dolt/

--- a/docs/end-session-design.md
+++ b/docs/end-session-design.md
@@ -1,0 +1,163 @@
+# /end-session — Design & Retrospective
+
+This document captures the reasoning behind the `/end-session` slash command's shape — in particular why its Phase 1 gather runs inside a dotfiles-managed shell script rather than inline.
+
+- Command spec: [`home/dot_claude/commands/end-session.md`](../home/dot_claude/commands/end-session.md)
+- Scripts: [`home/dot_claude/bin/`](../home/dot_claude/bin/)
+- Beads issue: `dotfiles-7rw` (Parallelize /end-session gather via dotfiles scripts)
+
+## What `/end-session` does
+
+Single-invocation tidy-up to leave a repo at a verifiable "clean walk-away" point: fetch + prune, rebase `main`, prune dead branches (merged and squash-merged), surface outstanding PRs / stashes / in-progress beads issues / worktrees, optionally push beads to Dolt, then offer the retrospective.
+
+Every step is classified by how much human judgment it needs:
+
+- **Tier 1** — auto-act, no prompt (fetch, pull, read-only lists).
+- **Tier 2** — auto-act behind one batched confirmation (branch deletes, push-if-ahead).
+- **Tier 3** — surface only, user drives (open PRs, in-progress issues, stashes, user-started processes).
+
+When in doubt we downgrade a tier rather than upgrade.
+
+## Retrospective — why the script split exists
+
+Two observations from using the command in anger.
+
+### Observation 1 — recurring approval prompts
+
+Two steps of Phase 1 triggered explicit approval prompts every run, even though every individual sub-command in them was already on the permission allowlist:
+
+- Step 1 (state gather) — a compound `echo "===pwd==="; pwd; echo "===status==="; git status ...` block.
+- Step 6 Batch B (squash-merged detection) — a pipeline of `git for-each-ref | awk | grep | while read … git diff …`.
+
+**Root cause.** The Claude Code permission matcher sees a Bash tool call as a single command string. A pattern like `Bash(git status *)` matches a call whose command begins with `git status` — it does **not** match a compound block that happens to contain `git status` alongside other commands. So compound blocks never match a narrow allow rule no matter how many of their pieces are allowed individually.
+
+Three ways to fix this:
+
+1. Pre-approve the exact compound strings. Brittle — any whitespace edit breaks the match.
+2. Split the block into N individual tool calls. Works for Step 1 but not for Step 6 Batch B's pipeline, and inflates tool-call count / output noise.
+3. Extract the compound logic into a script and allow the script's path. One rule; shellcheck-testable; editable without reshuffling permissions.
+
+We picked (3).
+
+### Observation 2 — round-trip latency dominates
+
+The original Phase 1 issued ~14 sequential Bash tool calls. For each one: the model emits the call, the runtime runs the command (often network-bound — `git fetch`, `gh run list`, `gh pr list`, `bd dolt push`), the result comes back, the model reads it and emits the next call. With a large context (1M), every round trip costs meaningful seconds of model latency **independent of** the command's own runtime.
+
+Of those 14 calls, 8 are independent read-only queries with no inter-dependencies — they can all run in parallel after `git fetch`. Serialising them doubled the latency for no correctness benefit.
+
+Extracting the gather into a script that runs `git fetch` first, then fans out the 8 reads with `&` + `wait`, collapses:
+
+- ~8 sequential tool calls into 1.
+- Summed serial network latency into max-of-parallel.
+- ~7 model-turn round-trips (each ~3–8s at 1M context) into 1.
+
+Measured on this repo (2026-04-21): Phase 1 gather wall time dropped from an estimated ~70s total to ~15s end-to-end (fetch-dominated). The remaining steps (Tier 2 destructive actions, `bd dolt push`, summary) are serial because they either need a y/n or depend on prior output.
+
+### Decision
+
+Extract two scripts, land one allow rule, rewrite Phase 1 to consume sectioned output. `/retrospective` was deliberately left alone — it's short, doesn't have multi-line approval blockers, and its value is in agentic reasoning rather than fixed commands; parallelisation would buy nothing.
+
+## Architecture
+
+```text
+/end-session  (home/dot_claude/commands/end-session.md)
+    │
+    ├── Step 1  → ~/.claude/bin/end-session-gather-state
+    │                  │
+    │                  ├── git fetch --all --prune --tags   (blocks)
+    │                  └── parallel fan-out:
+    │                        ├── local_state   (status, branch, log, origin)
+    │                        ├── stashes
+    │                        ├── worktrees
+    │                        ├── merged_brs
+    │                        ├── main_ci       (gh run list)
+    │                        ├── open_prs      (gh pr list)
+    │                        ├── bd_progress   (if .beads/)
+    │                        └── bd_preflight  (if .beads/)
+    │
+    ├── Steps 2, 3, 6A, 8–12  → read sections from gather output (no tool call)
+    ├── Step 4          → prompt on dirty/unpushed (reads local_state)
+    ├── Step 5          → git checkout main + git pull --rebase
+    ├── Step 6 Batch B  → ~/.claude/bin/end-session-squash-merged
+    ├── Step 7          → git log origin/main..HEAD (conditional push)
+    ├── Step 13         → background process housekeeping
+    ├── Step 14         → bd dolt push
+    └── Step 15         → agent-authored summary
+```
+
+## Output protocol — gather script
+
+```text
+===<section> (exit=<N>)===
+<section stdout+stderr>
+```
+
+Sections, in emission order: `fetch`, `local_state`, `stashes`, `worktrees`, `merged_brs`, `main_ci`, `open_prs`, `bd_progress`, `bd_preflight`. The two `bd_*` sections are absent entirely when `.beads/metadata.json` is missing.
+
+Progress pings go to stderr (`[gather] …`) so a human watching sees something move without polluting the parseable stream on stdout.
+
+### Exit code semantics
+
+| Outcome | Meaning |
+| --- | --- |
+| `exit=0`, empty content | Clean result — treat as "none". |
+| `exit=0`, content | Normal data — parse for the corresponding step. |
+| `exit != 0`, content `gh-unavailable` | Silent skip (no `gh` installed). Steps 3 and 8 degrade. |
+| `exit != 0`, other content | Real error — surface before continuing Phase 1. |
+
+Sections where empty output is expected (e.g., `merged_brs` grep returning no matches) append `|| true` inside the script so `exit=0` remains meaningful.
+
+## The squash-merged script
+
+Emits branches that satisfy both:
+
+1. `upstream: gone` — the tracking branch was deleted upstream (typical after a GitHub squash-merge + auto-delete).
+2. `git diff --quiet main..<branch>` succeeds — the branch's tree is already represented on main.
+
+Both are required. Rule 1 alone would include legitimate un-merged branches whose remote was deleted; rule 2 alone can't easily distinguish branches the user hasn't merged yet. Together, they identify branches whose content has landed via squash-merge and are safe for `-D`.
+
+## Permission model
+
+One allow rule covers both scripts and any future `end-session-*` sibling:
+
+```text
+Bash(~/.claude/bin/end-session-*)
+```
+
+Scope rationale: the prefix binds to scripts installed by this dotfiles repo (chezmoi renders `home/dot_claude/bin/executable_end-session-*` → `~/.claude/bin/end-session-*`). Scripts outside `~/.claude/bin/` aren't covered, so a rogue `end-session-*` elsewhere on disk still prompts.
+
+If the tilde pattern turns out not to match on some future Claude Code version, the fallback is an absolute path or a `bash $HOME/.claude/bin/end-session-*` form.
+
+## When to extract a step into a script vs keep it inline
+
+Favour a script when any of these hold:
+
+- The block is multi-line / pipelined in a way no single allow rule can match.
+- Multiple independent reads can be run in parallel inside it.
+- The logic is worth shellcheck-testing in isolation.
+- A future reader needs to see "what this step runs" without hunting through markdown.
+
+Keep it inline in the command spec when:
+
+- It's a single shell command that matches an existing allow rule.
+- It needs per-item user judgment between sub-commands (would break into separate prompts anyway).
+- It's runtime-level (background process state, agent memory) that can't run from a detached shell.
+
+## Rollout
+
+The scripts live in `home/dot_claude/bin/executable_end-session-*` in this repo. They materialise at `~/.claude/bin/end-session-*` (with exec bit) only after `chezmoi apply`. On this machine that's `dotup` — `chezmoi update -v` pulls + applies from `~/.local/share/chezmoi`.
+
+This matters because the dotfiles working clone (`/Users/paul/dev/dotfiles`, used for editing + PR workflow) and the chezmoi source clone (`~/.local/share/chezmoi`, what chezmoi reads) are separate. A merged PR to `main` does not land in `~/.claude/bin/` until chezmoi pulls and applies. First `/end-session` invocation on a machine after merging this work should be preceded by `dotup`.
+
+## Maintenance
+
+- **ShellCheck**: CI's `./scripts ./home` scan covers the scripts. Run locally with `shellcheck home/dot_claude/bin/executable_end-session-*` before pushing.
+- **Paired files**: `settings.json` and `settings.json.md` are paired — any change to the allow rule must update both.
+- **Adding a section to the gather**: add a `run_section` or `run_sh` call in the script, extend the section table in `commands/end-session.md`, then add a step (or fold into an existing step) that reads the new section.
+- **New sibling script**: name it `executable_end-session-<purpose>`; the existing permission rule covers it.
+
+## Non-goals
+
+- **Replacing `/retrospective`'s flow.** It doesn't suffer from the same approval-prompt or latency issues, and its value is in agentic reasoning — parallel gather has nothing to buy.
+- **Parallelising the destructive steps.** Tier 2 actions need a y/n each; splitting them across parallel processes would hide prompts.
+- **Auto-merging PRs or auto-closing issues.** Explicit non-goal of the command itself (see `Guardrails` in the spec).

--- a/home/dot_claude/bin/executable_end-session-gather-state
+++ b/home/dot_claude/bin/executable_end-session-gather-state
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# end-session-gather-state — parallel read-only state gather for /end-session.
+#
+# Runs `git fetch` first, then fans out independent read-only queries in
+# parallel, and collates results into a single sectioned stdout stream that
+# /end-session's Phase 1 consumes in one tool call.
+#
+# Output protocol (stdout):
+#   ===<section> (exit=<N>)===
+#   <section stdout+stderr>
+#
+# Progress pings go to stderr so a human watching sees something move;
+# parseable data is stdout-only.
+#
+# Exit codes per section are preserved so the agent can distinguish silent
+# skips ("gh-unavailable") from real errors.
+#
+# See docs/end-session-design.md for the reasoning.
+
+set -uo pipefail
+
+progress() { printf '[gather] %s\n' "$*" >&2; }
+
+TMP=$(mktemp -d -t end-session-gather.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Phase 1: git fetch (blocks remote-aware sections below) ---
+progress "git fetch --all --prune --tags"
+git fetch --all --prune --tags >"$TMP/fetch.out" 2>&1
+FETCH_EXIT=$?
+progress "fetch exit=$FETCH_EXIT"
+
+# --- Phase 2: parallel fan-out of independent reads ---
+# Each helper runs the command, captures stdout+stderr into <name>.out and
+# the exit code into <name>.exit. The subshell backgrounds with &.
+
+run_section() {
+    local name=$1
+    shift
+    (
+        "$@" >"$TMP/$name.out" 2>&1
+        echo $? >"$TMP/$name.exit"
+    ) &
+}
+
+run_sh() {
+    # Variant for shell pipelines. First arg is section name, second is the
+    # pipeline as a single string passed to `sh -c`.
+    local name=$1
+    local script=$2
+    (
+        sh -c "$script" >"$TMP/$name.out" 2>&1
+        echo $? >"$TMP/$name.exit"
+    ) &
+}
+
+# shellcheck disable=SC2016  # Intentional single quotes: expansion happens inside `sh -c`.
+run_sh local_state '
+    echo "pwd=$(pwd)"
+    echo "branch=$(git branch --show-current)"
+    echo "---status---"
+    git status --porcelain=v1 --branch
+    echo "---unpushed (vs @{u})---"
+    git log @{u}..HEAD --oneline 2>/dev/null | head -20
+    echo "---origin---"
+    git remote get-url origin 2>&1
+'
+
+run_section stashes git stash list
+run_section worktrees git worktree list
+
+run_sh merged_brs "
+    git branch --merged origin/main --format='%(refname:short)' \
+      | grep -vE '^(main|master|HEAD)\$' || true
+"
+
+run_sh main_ci '
+    if command -v gh >/dev/null 2>&1; then
+        gh run list --branch main --limit 10 \
+            --json status,conclusion,name,headSha,createdAt,url
+    else
+        echo "gh-unavailable"
+    fi
+'
+
+run_sh open_prs '
+    if command -v gh >/dev/null 2>&1; then
+        gh pr list --author @me --state open \
+            --json number,title,isDraft,mergeable,statusCheckRollup,reviewDecision,url
+    else
+        echo "gh-unavailable"
+    fi
+'
+
+if [ -f .beads/metadata.json ]; then
+    run_section bd_progress bd list --status=in_progress
+    run_section bd_preflight bd preflight
+fi
+
+wait
+progress "all sections complete"
+
+# --- Emit consolidated output ---
+emit() {
+    local name=$1
+    local exit_code
+    exit_code=$(cat "$TMP/$name.exit" 2>/dev/null || echo "n/a")
+    printf '===%s (exit=%s)===\n' "$name" "$exit_code"
+    cat "$TMP/$name.out" 2>/dev/null
+    printf '\n'
+}
+
+printf '===fetch (exit=%s)===\n' "$FETCH_EXIT"
+cat "$TMP/fetch.out"
+printf '\n'
+
+for s in local_state stashes worktrees merged_brs main_ci open_prs bd_progress bd_preflight; do
+    [ -f "$TMP/$s.exit" ] && emit "$s"
+done

--- a/home/dot_claude/bin/executable_end-session-squash-merged
+++ b/home/dot_claude/bin/executable_end-session-squash-merged
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# end-session-squash-merged — emit branches that are safe to force-delete
+# because they were squash-merged into main.
+#
+# A squash-merge on GitHub rewrites history, so `git branch --merged` does not
+# list them. After the remote branch is deleted they show up locally with
+# `upstream: gone`. Matching "upstream gone" AND "empty diff vs main" is the
+# safety net: if the working tree is already represented on main, `git branch
+# -D` is safe.
+#
+# Output: one branch name per line, ready for xargs or a confirmation prompt.
+# Exit: always 0 (empty output is a valid result).
+#
+# See docs/end-session-design.md.
+
+set -uo pipefail
+
+git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/ \
+    | awk '$2 ~ /gone/ { print $1 }' \
+    | grep -vE '^(main|master)$' \
+    | while read -r branch; do
+        git diff --quiet main.."$branch" 2>/dev/null && echo "$branch"
+      done || true

--- a/home/dot_claude/commands/end-session.md
+++ b/home/dot_claude/commands/end-session.md
@@ -22,48 +22,55 @@ git rev-parse --is-inside-work-tree 2>/dev/null || { echo "not a git repo"; exit
 
 ## Phase 1 — Tidy-up
 
-### 1. Gather state (read-only)
+### 1. Gather state (Tier 1 — one tool call)
 
-Run as a single shell block so the full picture lands in one output:
-
-```sh
-echo "===pwd==="; pwd
-echo "===current branch==="; git branch --show-current
-echo "===status==="; git status --porcelain=v1 --branch
-echo "===origin==="; git remote get-url origin 2>&1
-echo "===main branch name==="; git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
-echo "===unpushed commits on current branch==="; git log @{u}..HEAD --oneline 2>&1 | head -20
-echo "===beads workspace==="; [ -f .beads/metadata.json ] && echo "yes" || echo "no"
-```
-
-### 2. Fetch and prune remote-tracking refs (Tier 1)
+Run the parallel gather script. It does `git fetch --all --prune --tags` first, then fans out all read-only queries (status/branch/log, stashes, worktrees, merged branches, `main` CI, open PRs, beads in-progress, beads preflight) in parallel.
 
 ```sh
-git fetch --all --prune --tags
+~/.claude/bin/end-session-gather-state
 ```
+
+Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`. The sections are:
+
+| Section | Drives step(s) | Notes on exit code |
+| --- | --- | --- |
+| `fetch` | 2 (folded in) | Non-zero = network/auth issue — surface before proceeding. |
+| `local_state` | 1, 4 | Dirty tree + unpushed commits for step 4. |
+| `stashes` | 9 | Exit 0 even when empty. |
+| `worktrees` | 12 | Exit 0 even when empty. |
+| `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
+| `main_ci` | 3 | Content `gh-unavailable` = silent skip. Non-zero with other content = real error. |
+| `open_prs` | 8 | Same skip convention as `main_ci`. |
+| `bd_progress` | 10 | Section absent if no beads workspace. |
+| `bd_preflight` | 11 | Non-zero = preflight flagged something — surface its output. |
+
+Rules for interpreting exit codes:
+
+- `exit=0` with empty content: clean result (no stashes, no merged branches, no in-progress issues, etc.). Treat as "none".
+- `exit=0` with content: normal data — parse it for the relevant step.
+- `exit != 0` with content equal to `gh-unavailable`: silent skip (step 3 / step 8 degrade gracefully).
+- `exit != 0` with other content: real error — surface it before continuing Phase 1.
+
+### 2. Fetch and prune remote-tracking refs
+
+Folded into step 1's gather. The `fetch` section contains the output. If its exit code is non-zero, stop and surface before proceeding.
 
 ### 3. Check `main` CI status (Tier 1 — surface)
 
-If `gh` is available and the repo has a remote:
-
-```sh
-gh run list --branch main --limit 10 --json status,conclusion,name,headSha,createdAt,url 2>/dev/null
-```
-
-Parse the most recent run per workflow:
+From gather section `main_ci`. Parse the most recent run per workflow:
 
 - **Failed**: flag loudly with workflow name + URL. A red `main` is the loudest "not clean" signal.
 - **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
 - **All green**: silent.
 
-If `gh` isn't installed or there's no remote, skip silently. Carry the result forward — it gates the Phase 2 prompt.
+If the section content is `gh-unavailable` or the repo has no remote, skip silently. Carry the result forward — it gates the Phase 2 prompt.
 
 ### 4. Handle uncommitted or unpushed work (Tier 3)
 
-Before any branch switching or deletion:
+Read from gather section `local_state`. Before any branch switching or deletion:
 
-- **Dirty working tree** (uncommitted changes in `git status --porcelain`): stop, show the user what's dirty, ask whether to (a) commit, (b) stash, or (c) abort the tidy-up. Do **not** silently stash.
-- **Current branch has unpushed commits** and isn't `main`: surface this — ask whether to push (create PR if needed) or abort. Don't switch away from a branch with unpushed work without explicit permission.
+- **Dirty working tree** (non-empty `status` block): stop, show the user what's dirty, ask whether to (a) commit, (b) stash, or (c) abort the tidy-up. Do **not** silently stash.
+- **Current branch has unpushed commits** and isn't `main` (non-empty `unpushed` block): surface this — ask whether to push (create PR if needed) or abort. Don't switch away from a branch with unpushed work without explicit permission.
 
 ### 5. Return to main and rebase (Tier 1)
 
@@ -82,20 +89,12 @@ Two batches. Present each list, ask **one** y/n per batch, then act on the whole
 
 **Batch A — Branches fully merged into `origin/main`** (safe, uses `-d`):
 
-```sh
-git branch --merged origin/main --format='%(refname:short)' \
-  | grep -vE '^(main|master|HEAD)$'
-```
+Take the list from gather section `merged_brs`.
 
 **Batch B — Squash-merged branches** — branches whose upstream was deleted (`[upstream: gone]`, typical after GitHub squash-merge + branch delete) AND whose tree is identical to `main`. These won't show up in Batch A because squash-merging rewrites history; `-d` would refuse them. The empty-diff check is the safety net — if it passes, the content is already on `main` and `-D` is safe:
 
 ```sh
-git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/ \
-  | awk '$2 ~ /gone/ { print $1 }' \
-  | grep -vE '^(main|master)$' \
-  | while read -r branch; do
-      git diff --quiet main.."$branch" 2>/dev/null && echo "$branch"
-    done
+~/.claude/bin/end-session-squash-merged
 ```
 
 For each batch:
@@ -118,11 +117,7 @@ If main is ahead of origin/main (shouldn't normally happen, but catches the case
 
 ### 8. Open PRs needing your action (Tier 3 — surface only)
 
-For PRs you authored (open). Prefer `mcp__github__list_pull_requests` (state=open, head filter); fall back to:
-
-```sh
-gh pr list --author @me --state open --json number,title,isDraft,mergeable,statusCheckRollup,reviewDecision,url
-```
+From gather section `open_prs`. If the section content is `gh-unavailable`, either skip or fall back to `mcp__github__list_pull_requests` (state=open, head filter) — the MCP path doesn't need `gh` on PATH.
 
 Categorise and present:
 
@@ -136,39 +131,19 @@ Never auto-merge. List, link, move on.
 
 ### 9. Stashes (Tier 1 — surface)
 
-```sh
-git stash list
-```
-
-If non-empty, surface count + entries. Don't drop or apply anything.
+From gather section `stashes`. If non-empty, surface count + entries. Don't drop or apply anything.
 
 ### 10. Beads in-progress check (Tier 3 — surface)
 
-If beads workspace:
-
-```sh
-bd list --status=in_progress
-```
-
-Filter to issues claimed by the current user (assignee matches `git config user.email` or local username). Surface count + IDs/titles. User decides which to close — common forgetfulness pattern.
+From gather section `bd_progress` (absent if no beads workspace). Filter to issues claimed by the current user (assignee matches `git config user.email` or local username). Surface count + IDs/titles. User decides which to close — common forgetfulness pattern.
 
 ### 11. Beads preflight (Tier 1)
 
-If beads workspace:
-
-```sh
-bd preflight
-```
-
-Surface output. Includes lint, stale, orphans checks — all read-only.
+From gather section `bd_preflight` (absent if no beads workspace). Surface output. Includes lint, stale, orphans checks — all read-only.
 
 ### 12. Other worktrees (Tier 3 — surface)
 
-```sh
-git worktree list
-```
-
-If more than one entry, list non-primary worktrees with their branch. If any have uncommitted work, flag with `*`. Don't remove anything.
+From gather section `worktrees`. If more than one entry, list non-primary worktrees with their branch. If any have uncommitted work, flag with `*`. Don't remove anything.
 
 ### 13. Background processes
 

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -30,6 +30,7 @@
       "Bash(defaults find *)",
       "Bash(defaults read *)",
       "Bash(dolt *)",
+      "Bash(~/.claude/bin/end-session-*)",
       "Bash(/Applications/draw.io.app/Contents/MacOS/draw.io *)",
       "Bash(podman build *)",
       "Bash(podman compose *)",

--- a/home/dot_claude/settings.json.md
+++ b/home/dot_claude/settings.json.md
@@ -27,6 +27,20 @@ changing permission rules, update both files together.
 
 - `Bash(dolt *)`
 
+### End-of-session scripts
+
+The `/end-session` slash command delegates its multi-line gather and
+pipeline steps to dotfiles-managed scripts in `~/.claude/bin/`. Inline
+compound shell commands can't match single-pattern allow rules (a
+command like `echo A; git status; echo B` is one string to the matcher,
+not three matches), so extracting them to scripts + one prefix rule
+removes recurring approval prompts. One rule covers current and future
+`end-session-*` scripts; scoped narrowly by prefix.
+
+- `Bash(~/.claude/bin/end-session-*)`
+
+See `docs/end-session-design.md` for the full rationale.
+
 ### draw.io (CLI export, read-only)
 
 - `Bash(/Applications/draw.io.app/Contents/MacOS/draw.io *)`


### PR DESCRIPTION
## Summary

- Extracts `/end-session` Phase 1's multi-line state gather and squash-merged branch detection into shell scripts under `~/.claude/bin/`, fanning read-only queries out with `&` + `wait` so network I/O overlaps.
- Removes the two recurring approval prompts the command used to trigger (root cause: compound shell commands don't match single-pattern allow rules — one call is one string to the matcher, even if every sub-command is individually allowed).
- Collapses ~8 sequential tool calls into 1 and drops Phase 1 wall time from ~70s to ~15s, measured on this repo.

## Changes

- **`home/dot_claude/bin/executable_end-session-gather-state`** — parallel reader for `local_state`, `stashes`, `worktrees`, `merged_brs`, `main_ci`, `open_prs`, `bd_progress`, `bd_preflight`. Sectioned stdout with per-section exit codes; progress pings to stderr.
- **`home/dot_claude/bin/executable_end-session-squash-merged`** — isolates the `upstream: gone` + empty-diff pipeline into its own script.
- **`home/dot_claude/commands/end-session.md`** — Phase 1 steps 1–3 and 6B/8–12 now read from gather sections instead of issuing inline shell.
- **`home/dot_claude/settings.json` / `settings.json.md`** — one new allow rule `Bash(~/.claude/bin/end-session-*)` covers both scripts and any future `end-session-*` sibling.
- **`.gitignore`** — anchor `bin/` → `/bin/` so nested `home/dot_claude/bin/` is no longer shadowed by the root-level rule.
- **`docs/end-session-design.md`** — retrospective (why this refactor exists), architecture overview, rollout notes, maintenance guidance.

## Design notes

The why + the output protocol + when-to-extract-a-script guidance live in `docs/end-session-design.md`, not the PR body, so future changes have a stable reference.

Beads issue: `dotfiles-7rw`. Follows #160 which added the Phase 1 structure this PR is now parallelising.

## Test plan

- [x] `shellcheck home/dot_claude/bin/executable_end-session-*` — clean
- [x] `markdownlint-cli2` on all touched markdown — clean
- [x] `jq -e . home/dot_claude/settings.json` — valid JSON
- [x] Live gather run on this repo — all 8 sections populate correctly, exit codes sensible, ~15s wall time
- [x] Squash-merge script correctly flagged a known-mergeable branch
- [ ] CI passes (shellcheck / markdownlint / actionlint / Test Install matrix)
- [ ] Post-merge: run `dotup` on this machine so `~/.claude/bin/end-session-*` materialises, then re-invoke `/end-session` to confirm no approval prompts and section parsing works end-to-end

## Rollout caveat

Scripts only exist at `~/.claude/bin/` after `chezmoi apply`. First `/end-session` invocation on a given machine after this merges should be preceded by `dotup`.
