### PR TITLE
docs(readme): lead with user-benefit framing and surface dot* helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,105 @@
 Personal dotfiles managed by [chezmoi](https://www.chezmoi.io/). Provides a
 consistent dev environment across macOS, Linux, WSL, and Windows.
 
+## What You Get
+
+One curl command on a fresh machine and you walk away with a tuned shell, a
+modern CLI toolkit, your editors and Git already configured, secrets
+decrypted, and a Claude Code setup that knows how to scaffold any new
+language project — all kept in sync across every machine you own with two
+short commands.
+
+### One install, three platforms
+
+Works on **macOS, Ubuntu/Debian Linux, WSL, and Windows** from the same
+source of truth. Pick a tier at install time (`personal` / `work` /
+`minimal`) so a work laptop doesn't get Steam and a minimal VM doesn't get
+the full kitchen sink.
+
+### A polished terminal
+
+Zsh + Oh My Zsh with quality-of-life add-ons:
+
+- **`zsh-autosuggestions`** — fish-style as-you-type history suggestions
+- **`zsh-syntax-highlighting`** — commands turn green/red before you press
+  Enter
+- **`colored-man-pages`**, **`command-not-found`**, **`extract`** (one
+  command for any archive), **`copypath`**, **`copyfile`**
+- **Starship prompt** with transient-prompt collapse so scrollback stays
+  clean
+- **fzf** wired for `Ctrl-R` history search and fuzzy file pickers
+- **zoxide** so `z proj` jumps to your most-used folder without typing the
+  path
+- Bitwarden SSH agent auto-wired, telemetry opted out, `~/.zshrc.local`
+  escape hatch for per-machine tweaks
+
+### A modern CLI toolkit installed for you
+
+- **Better core tools** — `bat`, `fd`, `ripgrep`, `git-delta`, `jq`/`yq`,
+  `fzf`, `zoxide`
+- **Git + dev** — `gh`, `lazygit`, `pre-commit`, `gitleaks`
+- **Languages** — Go, .NET, OpenJDK + `jenv`, `nvm`, `uv` (Python), Rust
+- **Cloud / infra** — `gcloud`, `awscli`, `azure-cli`, `tenv` + `tflint`,
+  `checkov`, `trivy`, `semgrep`, `podman`
+- **Personal-tier GUI apps** — VS Code, Ghostty, Bitwarden, Rectangle,
+  Chrome, JetBrains Mono Nerd Font, Claude Desktop, and more
+
+### Short, memorable maintenance commands
+
+You don't need to remember chezmoi or brew incantations:
+
+- **`dotup`** — pull latest dotfiles, update Oh My Zsh + plugins, refresh
+  nano syntax, update Starship (Linux) and Rust toolchain, then reload
+  aliases/functions in the current shell
+- **`dotbrew`** — `brew update` + install everything in your Brewfile +
+  `brew upgrade`, in one step
+- **`dotclaude`** — interactive Claude Code MCP server setup (GitHub MCP
+  wired to your `gh` auth token, Google Developer Knowledge keyed from
+  Bitwarden)
+- **`dotstatus`** — machine type, source path, last applied, and any
+  pending changes
+- **`dotfuncs`** — list every custom function with its one-line description
+  so you can rediscover what's available after `dotup`
+
+### Quick-capture project notes
+
+- **`note "anything"`** (alias **`n`**) — append a timestamped bullet to
+  `~/notes/<project>.md`, where project is the git repo basename (or cwd
+  basename outside a repo). No args → print the current project's notes.
+- **`note -e`** — open the current project's notes file in `$EDITOR`
+- **`notes`** — list all note files across projects
+- **`notes grep <pattern>`** (or just `notes <pattern>`) —
+  case-insensitive search across every project's notes
+
+### A centralised Claude Code setup that follows you everywhere
+
+Every machine gets the same `~/.claude/` config:
+
+- Curated permission allowlist so common dev/build/lint/GitHub commands
+  don't prompt every time, but destructive things still do
+- Slash commands to bootstrap any project — `/setup-python`, `/setup-go`,
+  `/setup-rust`, `/setup-node`, `/setup-typescript`, `/setup-java`,
+  `/setup-ruby`, `/setup-php`, `/setup-dotnet`, `/setup-shell`,
+  `/setup-markdown`, `/setup-docker`, `/setup-terraform` — each wires
+  formatter + linter + type checks + pre-commit hooks consistently
+- Repo helpers — `/setup-repo` (branch protection, Dependabot auto-merge),
+  `/setup-common` (pre-commit + gitleaks)
+- Session helpers — `/end-session`, `/retrospective`
+- Auto-fix hooks — Terraform formatted on save, pre-commit enforced before
+  `git push`
+
+### Secrets handled safely
+
+`age`-based encryption — secrets live in the repo encrypted, decrypt on
+first run with your key. No plaintext credentials in version control.
+
+### Confidence it works
+
+CI runs lint + full install tests on macOS, Ubuntu, and Windows on every
+push to `main`, so a broken bootstrap is caught before it hits your laptop.
+`validate-installation.sh` (and `.ps1` for Windows) sanity-checks a fresh
+install.
+
 ## Quick Start
 
 ### macOS / Linux / WSL
@@ -60,7 +159,29 @@ run `chezmoi apply`.
 
 ## Usage
 
-### Daily Commands
+### Daily helpers
+
+```bash
+dotup                 # Pull latest dotfiles + update OMZ, plugins, Starship, Rust
+dotbrew               # brew update + install Brewfile + brew upgrade
+dotclaude             # Interactive Claude Code MCP server setup
+dotstatus             # Machine type, source path, last applied, pending changes
+dotfuncs              # List all custom shell functions with descriptions
+```
+
+### Quick-capture notes
+
+```bash
+note "fixed the auth bug"   # Append a timestamped bullet to ~/notes/<project>.md
+n "another shorthand"        # 'n' is an alias for 'note'
+note                          # Print the current project's notes
+note -e                       # Open the current project's notes in $EDITOR
+notes                         # List all note files
+notes grep <pattern>          # Search across every project's notes
+notes <pattern>               # Shorthand for 'notes grep'
+```
+
+### Direct chezmoi commands
 
 ```bash
 chezmoi diff          # Preview pending changes
@@ -69,14 +190,7 @@ chezmoi edit ~/.zshrc # Edit a managed file
 chezmoi add ~/.foo    # Start managing a new file
 ```
 
-### Updating
-
-```bash
-dotup                 # Update dotfiles, brew, OMZ, plugins, and starship
-dotstatus             # Show machine type, source path, pending changes
-```
-
-### Package Management
+### Package management
 
 ```bash
 # macOS — packages auto-install when Brewfile changes

--- a/README.md
+++ b/README.md
@@ -121,27 +121,14 @@ This installs chezmoi, packages (Homebrew/apt/winget), shell config (Zsh +
 Oh My Zsh or PowerShell), Starship prompt, git-delta, lazygit, tmux, VS Code
 settings, JetBrains Mono Nerd Font, and platform-specific defaults.
 
-## What's Included
+## Per-Platform Reference
 
-### Shell
-
-- **Unix**: Zsh + Oh My Zsh (autosuggestions, syntax-highlighting, history, etc.)
-- **Windows**: PowerShell Core with enhanced profile
-- **Prompt**: Starship (all platforms)
-- **Terminal**: Ghostty (macOS), Windows Terminal (Windows)
-- **Multiplexer**: tmux (Unix)
-
-### Dev Tools
-
-- **Packages**: Brewfile (macOS), apt list (Linux), winget JSON (Windows)
-- **Git**: git-delta diffs, lazygit TUI, global gitignore
-- **Editor**: VS Code with synced settings and keybindings
-- **Fonts**: JetBrains Mono Nerd Font
-
-### Security
-
-- **Secrets**: age encryption for sensitive configs
-- **Platform tweaks**: macOS developer defaults, Windows Long Paths + Developer Mode
+| | macOS | Linux / WSL | Windows |
+| --- | --- | --- | --- |
+| Shell | Zsh + Oh My Zsh | Zsh + Oh My Zsh | PowerShell Core |
+| Terminal | Ghostty | (host terminal) | Windows Terminal |
+| Package source | `Brewfile` | `apt` package list | `winget` JSON |
+| Platform tweaks | Developer defaults | — | Long Paths + Developer Mode |
 
 ## Machine Types
 


### PR DESCRIPTION
Add a "What You Get" section above Quick Start covering the polished
terminal, modern CLI toolkit, dot* maintenance commands, note/n
quick-capture, centralised Claude Code setup, secrets handling, and CI
confidence. Promote dotup/dotbrew/dotclaude/dotstatus/dotfuncs and the
note/notes helpers to the top of the Usage section so daily commands are
discoverable.

https://claude.ai/code/session_01FThG6FYegwte3pi52CKCSL