### PR TITLE
docs(readme): drop stale Stow migration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,6 @@ chezmoi apply
 
 Highly sensitive secrets (API keys, passwords) belong in Bitwarden, not here.
 
-## Migrating from Old Setup (Stow)
-
-See [docs/MIGRATION.md](docs/MIGRATION.md) for the full cleanup guide
-covering stow symlink removal, Oh My Posh → Starship transition, and
-per-platform notes.
-
 ## Platform Support
 
 - macOS (Sonoma and later)


### PR DESCRIPTION
The "Migrating from Old Setup (Stow)" section pointed to docs/MIGRATION.md,
which no longer exists, and no machines remain on the old framework. Remove
the section entirely.

https://claude.ai/code/session_01FThG6FYegwte3pi52CKCSL