### PR TITLE
feat(claude): /start-session auto-switches back to main when upstream is gone

### DIFF
--- a/home/dot_claude/bin/executable_start-session-gather-state
+++ b/home/dot_claude/bin/executable_start-session-gather-state
@@ -75,8 +75,19 @@ run_sh local_state '
         ahead=$(git rev-list --count "@{u}..HEAD" 2>/dev/null)
         behind=$(git rev-list --count "HEAD..@{u}" 2>/dev/null)
         echo "ahead=$ahead behind=$behind"
+        echo "upstream_status=alive"
     else
-        echo "(no upstream)"
+        # Distinguish "configured upstream but remote ref pruned" (gone) from
+        # "no upstream ever set" (none). The gone state is the canonical
+        # signal that a PR was merged and the remote branch auto-deleted.
+        upstream_ref=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || true)
+        if [ -n "$upstream_ref" ]; then
+            echo "(no upstream ref — pruned)"
+            echo "upstream_status=gone"
+        else
+            echo "(no upstream)"
+            echo "upstream_status=none"
+        fi
     fi
     echo "---vs origin/$DEFAULT_BRANCH---"
     if git rev-parse --verify --quiet "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then

--- a/home/dot_claude/commands/start-session.md
+++ b/home/dot_claude/commands/start-session.md
@@ -58,14 +58,26 @@ Folded into step 1's gather. The `fetch` section contains the output. If its exi
 
 ### 3. Sync the default branch (Tier 1 / Tier 3)
 
-Read `local_state`. Behavior depends on which branch you're on:
+Read `local_state`, including the `upstream_status` line (`alive` / `gone` / `none`). Behavior depends on which branch you're on:
 
 - **On the default branch** (`branch` matches `default_branch`) and behind `origin/<default>`: run `git pull --rebase --autostash`. Tier 1.
 - **On the default branch** and clean / up-to-date: silent.
-- **On a feature branch** with `default_branch` advanced (`vs origin/<default>` shows non-zero `behind`): surface the count — "`<default>` is N commits ahead of your branch". Do **not** auto-rebase. Tier 3 — the user decides whether to rebase, merge, or carry on.
+- **On a feature branch with `upstream_status=gone` and a clean working tree**: auto-switch back to the default branch and bring it up to date. Tier 1.
+
+  `upstream_status=gone` means an upstream is configured in `.git/config` but its remote ref has been pruned during fetch — the canonical signal that the PR was merged and the branch was auto-deleted on the remote. Run:
+
+  ```sh
+  git checkout <default_branch>
+  git pull --rebase --autostash
+  ```
+
+  Add `auto-switched <feature> → <default> (upstream gone)` as an extra line under `Sync:` in the session brief. Leave the local feature branch in place — never delete it. The user can return to it with `git checkout <feature>` if they need to.
+
+- **On a feature branch with `upstream_status=gone` but the working tree is dirty**: do NOT auto-switch. The dirty work might sit on top of commits that are now squash-merged into `main`, and switching would risk surprising the user. Surface as Tier 3: `<branch>'s upstream is gone (PR merged?) but tree is dirty — commit or stash, then switch manually`.
+- **On a feature branch with `upstream_status=alive`** and `default_branch` advanced (`vs origin/<default>` shows non-zero `behind`): surface the count — "`<default>` is N commits ahead of your branch". Do **not** auto-rebase. Tier 3 — the user decides whether to rebase, merge, or carry on.
 - **On a feature branch with unpushed commits** (non-zero `ahead` vs `@{u}`): surface the count. Don't push from here; that's `/end-session`'s job.
 
-Never switch branches. The user's current branch is left alone.
+Don't switch branches outside of the auto-switch case above.
 
 ### 4. Beads Dolt pull (Tier 1)
 
@@ -115,7 +127,8 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 ```text
 ── Session brief ──────────────────────────────
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
-Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/n/a>
+Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
+          [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 Dolt:     <pulled / up-to-date / no remote / FAILED>
 CI:       <green / N failing / N in-progress / n/a>
 
@@ -130,7 +143,8 @@ Needs attention:
   • <unmigrated GH issues: N>      (omit when 0 / n/a)
   • <main CI red on workflow X>    (omit when green)
   • <bd preflight flagged …>       (omit when clean)
-  • <feature branch behind main by N>  (omit when on default or even)
+  • <feature branch behind main by N>          (omit when on default, even, or auto-switched)
+  • <branch upstream gone but tree dirty>      (omit unless that case fires)
 ───────────────────────────────────────────────
 ```
 
@@ -146,7 +160,7 @@ Rules:
 
 - **Pre-flight gate is non-negotiable.** Never proceed when not in a git repo.
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
-- **Never switch branches.** `/start-session` reports state on whatever branch the user is on.
+- **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `/start-session` reports state on whatever branch the user is on.
 - **`bd dolt pull` failures halt the phase.** Don't attempt auto-resolve, don't fall back to JSONL, don't rebuild the DB. Surface and stop.
 - **Don't push anything.** Pushes belong to `/end-session` (for git/`main`) and `/bd-import-github-issues` (for beads after import). `/start-session` is read-mostly.
 - **Don't modify settings, config, or unrelated files.** Scope is git, beads, and GitHub-issue surface only.


### PR DESCRIPTION
## Summary

- Detects the canonical "PR merged and branch auto-deleted on GitHub" state and resolves it without prompting: when the current feature branch has an `upstream_status=gone` and the working tree is clean, `/start-session` now `git checkout`s the default branch and `git pull --rebase --autostash`es it.
- Dirty-tree case (uncommitted work) stays Tier 3 — surfaced only, never auto-switched, since the dirty work might rest on commits that were squashed into `main`.
- Adds a structured `upstream_status` field (`alive` / `gone` / `none`) to the gather script's `local_state` section. Previously the `gone` and `none` cases both rendered as `(no upstream)`, so the agent couldn't tell them apart.

## What changed

- `home/dot_claude/bin/executable_start-session-gather-state` — emit `upstream_status=…` line under `---vs upstream (@{u})---`.
- `home/dot_claude/commands/start-session.md` — Step 3 gains the auto-switch rule and the dirty-tree carve-out; Guardrails section relaxes "Never switch branches" with the same carve-out; brief format gains a conditional `auto-switched X → Y` line.

## Test plan

- [x] `shellcheck` clean on the gather script
- [x] `markdownlint-cli2` clean on `start-session.md`
- [x] Smoke test: ran the gather script on a fresh never-pushed branch — `upstream_status=none` emitted as expected
- [ ] End-to-end verification will happen on next session start: branch will be deleted on merge, next `/start-session` should auto-switch back to `main`

Refs dotfiles-0zc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)