### PR TITLE
fix(ci): ghostty terminfo workflow opens a PR instead of pushing to main

### DIFF
--- a/.github/workflows/ghostty-terminfo.yml
+++ b/.github/workflows/ghostty-terminfo.yml
@@ -12,7 +12,8 @@ jobs:
     name: Generate Ghostty Terminfo
     runs-on: macos-latest
     permissions:
-      contents: write  # Required to commit and push changes
+      contents: write        # Required to push to the bot-owned chore branch
+      pull-requests: write   # Required to open / update the chore PR
 
     steps:
       - name: Checkout repository
@@ -60,15 +61,35 @@ jobs:
             echo "Changes detected in $TERMINFO_PATH"
           fi
 
-      - name: Commit and push if changed
+      - name: Open or update PR with terminfo refresh
         if: steps.check_changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/ghostty-terminfo-update
         run: |
           git config --local user.email \
             "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
+          # Stable bot-owned branch — repeated weekly runs update the same
+          # PR rather than stacking new ones. Force-push is safe here because
+          # nothing else writes to this ref.
+          git checkout -b "$BRANCH"
           git add home/dot_config/ghostty/xterm-ghostty.terminfo
           git commit -m "chore: update xterm-ghostty.terminfo"
-          git push
+          git push --force origin "$BRANCH"
+
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open \
+            --json number --jq '.[0].number')
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: update xterm-ghostty.terminfo" \
+              --body "Automated weekly refresh from the \`Generate Ghostty Term Info\` workflow."
+          else
+            echo "PR #$EXISTING_PR already open; pushed updated terminfo to its branch."
+          fi
 
       - name: Upload terminfo as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Summary

- Replaces direct `git push` to `main` with a bot-PR pattern. The scheduled `Generate Ghostty Term Info` workflow was failing every week with `GH006: Protected branch update failed for refs/heads/main` since `main` is now branch-protected. Last failure: [run 24944486199](https://github.com/pmgledhill102/dotfiles/actions/runs/24944486199) on `cf20c1a` (2026-04-26 00:42 UTC).
- Workflow now commits on a stable bot-owned branch `chore/ghostty-terminfo-update`, force-pushes, and either opens a fresh PR or leaves the existing one updated. Stable branch name keeps weekly runs from stacking new PRs.
- Adds `pull-requests: write` to the job's `permissions` block.

## Why force-push the chore branch

Nothing else writes to `chore/ghostty-terminfo-update` — it's exclusively the bot's. Force-push gives us a clean "current main + terminfo update" diff every week, so the open PR always reflects the latest state.

## Test plan

- [x] `actionlint` clean
- [x] Verified `gh pr list --head <branch> --state open` is the right idiom for the open-PR check
- [ ] Wait for CI on this PR
- [ ] Once merged, manually trigger via `workflow_dispatch` to verify end-to-end behaviour (PR is created or updated)

Closes dotfiles-kni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)