### PR TITLE
docs(claude): clarify bd in_progress vs blocked symbols in /end-session

### DIFF
--- a/home/dot_claude/commands/end-session.md
+++ b/home/dot_claude/commands/end-session.md
@@ -43,7 +43,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
 | `main_ci` | 3 | Content `gh-unavailable` = silent skip. Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
-| `bd_progress` | 10 | Section absent if no beads workspace. |
+| `bd_progress` | 10 | Section absent if no beads workspace. All entries are `in_progress` by definition (that's the filter) — see step 10 for symbol-reading rules. |
 | `bd_preflight` | 11 | Non-zero = preflight flagged something — surface its output. |
 
 Rules for interpreting exit codes:
@@ -137,7 +137,12 @@ From gather section `stashes`. If non-empty, surface count + entries. Don't drop
 
 ### 10. Beads in-progress check (Tier 3 — surface)
 
-From gather section `bd_progress` (absent if no beads workspace). Filter to issues claimed by the current user (assignee matches `git config user.email` or local username). Surface count + IDs/titles. User decides which to close — common forgetfulness pattern.
+From gather section `bd_progress` (absent if no beads workspace). The section is the output of `bd list --status=in_progress`, so **every entry is in_progress** — never report these as "blocked". Filter to issues claimed by the current user (assignee matches `git config user.email` or local username). Surface count + IDs/titles. User decides which to close — common forgetfulness pattern.
+
+**Reading bd's symbols (don't conflate them):**
+- The leading glyph on each line is the **status**: `○` open · `◐` in_progress · `●` blocked · `✓` closed · `❄` deferred. In this section it's always `◐`.
+- A `●` appearing later in the line (e.g., inside `[● P2]`) is a **priority indicator**, not a blocked-status flag. The bd legend printed at the bottom of `bd list` uses `●` for "blocked" and reuses the same glyph for priority — that collision is the trap.
+- If you want to know what's actually blocked, run `bd blocked` — don't infer from later-line glyphs.
 
 ### 11. Beads preflight (Tier 1)
 

--- a/home/dot_claude/commands/end-session.md
+++ b/home/dot_claude/commands/end-session.md
@@ -140,6 +140,7 @@ From gather section `stashes`. If non-empty, surface count + entries. Don't drop
 From gather section `bd_progress` (absent if no beads workspace). The section is the output of `bd list --status=in_progress`, so **every entry is in_progress** — never report these as "blocked". Filter to issues claimed by the current user (assignee matches `git config user.email` or local username). Surface count + IDs/titles. User decides which to close — common forgetfulness pattern.
 
 **Reading bd's symbols (don't conflate them):**
+
 - The leading glyph on each line is the **status**: `○` open · `◐` in_progress · `●` blocked · `✓` closed · `❄` deferred. In this section it's always `◐`.
 - A `●` appearing later in the line (e.g., inside `[● P2]`) is a **priority indicator**, not a blocked-status flag. The bd legend printed at the bottom of `bd list` uses `●` for "blocked" and reuses the same glyph for priority — that collision is the trap.
 - If you want to know what's actually blocked, run `bd blocked` — don't infer from later-line glyphs.


### PR DESCRIPTION
## Summary

The `/end-session` gather output for `bd_progress` was misread mid-session as "all 3 issues blocked" when in fact they were all `in_progress`. Cause: `bd list` prints the **priority** indicator using `●` (e.g. `[● P2]`), and the legend at the bottom of the same output uses `●` to mean **blocked** — same glyph, two meanings.

This PR adds explicit guidance to `home/dot_claude/commands/end-session.md`:
- Section table row for `bd_progress` now points at the symbol-reading rules.
- Step 10 spells out: every entry in this section is `in_progress` (it's the filter), the leading `◐` is the status, and a later `●` is a priority dot — not a blocked flag. To find actually-blocked issues, run `bd blocked`.

Refs: `dotfiles-1yw`

## Test plan

- [ ] Markdown lints clean (CI)
- [ ] Next `/end-session` run reports `Beads in_progress (yours): N` without saying "blocked"