### PR TITLE
fix(beads): restore dispatcher chain in .beads/hooks/ (bump v1.0.2 → v1.0.3)

### DIFF
--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,5 +1,16 @@
-#!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+#!/bin/sh
+# No set -e — post-checkout failures should not block
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+# Only run on branch checkout ($3 = "1"), not file checkout
+[ "${3:-0}" = "1" ] || exit 0
+
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +32,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,5 +1,13 @@
-#!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+#!/bin/sh
+# No set -e — post-merge failures should not block
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +29,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,5 +1,15 @@
-#!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+#!/bin/sh
+set -e
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+run_precommit pre-commit
+
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +31,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,5 +1,15 @@
-#!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+#!/bin/sh
+set -e
+
+# Source dispatch library (central first, local fallback)
+_lib="${HOME}/.git-templates/hooks/_lib/dispatch.sh"
+[ -f "$_lib" ] || _lib="$(dirname "$0")/_lib/dispatch.sh"
+# shellcheck source=_lib/dispatch.sh
+. "$_lib"
+
+run_precommit pre-push
+
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +31,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.3 ---


### PR DESCRIPTION
## Summary

Pre-commit framework hooks (markdownlint, etc.) had silently stopped running on every commit in this repo. Root cause: bd's hook-relocation migration from v0.62.x (inline injection into `.git/hooks/<name>`) to v1.0.x (relocate to `.beads/hooks/`, override `core.hooksPath`) hit a bug in bd's `preservePreexistingHooks` (`cmd/bd/hooks.go:724-728`) — it skips copying any existing hook whose content contains the legacy `# --- BEGIN BEADS INTEGRATION` marker, treating it as already-bd-managed. But these hooks were **dispatcher + bd marker block** — the dispatcher (with its `run_precommit` call) got discarded, only the bare bd shim landed in `.beads/hooks/<name>`.

CI was the only line of defence — local lint hooks weren't firing.

## Fix in this repo

Three steps, fully reversible:

1. Refresh `.git/hooks/<name>` from the current `~/.git-templates/hooks/` (post-#153, no legacy marker).
2. `git config --unset core.hooksPath` and `rm -rf .beads/hooks` to give bd a clean preservation slate.
3. `bd hooks install --beads` — preservation now copies the dispatcher into `.beads/hooks/<name>` and injects the v1.0.3 `BEADS INTEGRATION` block beneath it.

Result for each managed hook is now the *fused* file the v1.0.x design intended:

```sh
#!/bin/sh                                # ← from ~/.git-templates dispatcher
. _lib/dispatch.sh
run_precommit pre-commit                 # ← runs pre-commit framework

# --- BEGIN BEADS INTEGRATION v1.0.3 --- # ← appended by bd
... bd hooks run pre-commit ...
# --- END BEADS INTEGRATION v1.0.3 ---
```

## Verified

A deliberately bad-markdown commit (MD022 + MD032) is now blocked locally by the same rules CI runs, with HEAD unchanged.

## Upstream

The marker-skip bug is still present on beads `main` (v1.0.3). Filing upstream as a follow-up. Anyone migrating v0.62.x → v1.0.x with non-trivial content in `.git/hooks/<name>` (custom dispatchers, husky, lefthook, etc.) is exposed.

Refs: `dotfiles-b0a`

## Test plan

- [ ] CI green
- [ ] Verify on next commit: `markdownlint-cli2` line appears in pre-commit output (means the dispatcher's `run_precommit` ran)