### PR TITLE
chore(ci): pin actions/upload-artifact to v7.0.1 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,7 +509,7 @@ jobs:
 
     - name: Upload Test Results
       if: failure()
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-results-${{ matrix.os }}
         path: |


### PR DESCRIPTION
## Summary

- Replace floating-tag `actions/upload-artifact@v7.0.1` reference at `ci.yml:512` with the pinned commit SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`.
- Last remaining floating-tag pin in the workflows; matches the SHA already used in `ghostty-terminfo.yml:95`.

Closes dotfiles-r77.

## Test plan

- [ ] CI green on this PR (the upload-artifact step only fires on test failure, so green CI implicitly validates the workflow still parses).