### PR TITLE
docs(adrs): correct ADR-0005 brewfile install hook description

### DIFF
--- a/docs/adrs/0005-brewfile-canonical-macos-packages.md
+++ b/docs/adrs/0005-brewfile-canonical-macos-packages.md
@@ -23,8 +23,9 @@ Macos packages live exclusively in `home/Brewfile.tmpl`.
   the active machine type (personal / work / minimal).
 - `dotbrew` runs `brew update`, `brew bundle install --file ~/Brewfile`,
   then `brew upgrade` — the daily refresh path.
-- `run_onchange_after_install-brewfile.sh.tmpl` ensures fresh installs
-  install the bundle automatically when the Brewfile content changes.
+- `run_once_after_install-brewfile.sh.tmpl` runs the bundle install on the
+  first `chezmoi apply`, so a fresh machine bootstraps the full package set
+  without manual intervention. Ongoing updates run through `dotbrew`.
 - apt and winget lists do not duplicate Homebrew formulae.
 
 ## Consequences


### PR DESCRIPTION
## Summary

ADR-0005 described the install hook as `run_onchange_after_install-brewfile.sh.tmpl` with on-change semantics. The actual file is `run_once_after_install-brewfile.sh.tmpl` with first-apply-only semantics — `dotbrew` handles ongoing updates (already covered in the previous bullet).

Aligning the ADR text with the implementation. **No behaviour change** — text-only fix.

The alternative (renaming the script to `run_onchange_…`) was considered and rejected: it would re-trigger the install on every Brewfile content change for existing machines, which isn't the intent.

Closes dotfiles-qv3.

## Test plan

- [ ] markdownlint passes (already shown locally during pre-commit).
- [ ] CI green on this PR.