### PR TITLE
docs(readme): point Linux package edits at [data.packages.apt]

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,10 @@ chezmoi add ~/.foo    # Start managing a new file
 # macOS — packages auto-install when Brewfile changes
 brew bundle
 
-# Linux — packages auto-install when list changes
-chezmoi edit ~/.config/ubuntu_pkglist
+# Linux — apt packages live under [data.packages.apt] in
+# home/.chezmoi.toml.tmpl; the rendered ~/.config/ubuntu_pkglist
+# regenerates from it, and changes auto-install on the next apply.
+chezmoi init --apply
 ```
 
 ## Secret Management


### PR DESCRIPTION
## Summary

The README told users to `chezmoi edit ~/.config/ubuntu_pkglist` to manage Linux packages. But that file is generated from `[data.packages.apt]` in `home/.chezmoi.toml.tmpl` on every apply — its own header literally says `# To add/remove packages, edit .chezmoi.toml.tmpl under [data.packages.apt]`. Direct edits to the rendered file are silently overwritten on the next chezmoi apply.

Redirect users to the canonical source. **Doc-only change** — no code touched.

Closes dotfiles-aoj.

## Test plan

- [ ] markdownlint passes (already shown locally during pre-commit).
- [ ] CI green on this PR.