### PR TITLE
feat(claude): allow Bash(git switch *) in permissions

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -168,6 +168,7 @@
       "Bash(git show *)",
       "Bash(git stash *)",
       "Bash(git status *)",
+      "Bash(git switch *)",
       "Bash(git tag *)",
       "Bash(git worktree *)",
       "Bash(gitleaks *)",

--- a/home/dot_claude/settings.json.md
+++ b/home/dot_claude/settings.json.md
@@ -258,6 +258,7 @@ Deliberately **not** auto-allowed:
 - `Bash(git show *)`
 - `Bash(git stash *)`
 - `Bash(git status *)`
+- `Bash(git switch *)`
 - `Bash(git tag *)`
 - `Bash(git worktree *)`
 


### PR DESCRIPTION
## Summary

Adds `Bash(git switch *)` to the Claude Code allowlist (alphabetically between `git status *` and `git tag *`), with the matching entry in the annotated `settings.json.md` companion.

**Why**: every branch switch during multi-PR workflows currently prompts for permission. Hit several times in this session.

**Why it's safe**:

- Plain `git switch <branch>` and `git switch -c <branch>` refuse to overwrite uncommitted changes by default — git will return a "Please commit your changes or stash them..." error.
- The destructive variants (`-f` / `--discard-changes` / `-C`) remain covered by the global `CLAUDE.md` policy rule: *"NEVER run destructive git commands... unless the user explicitly requests these actions."* Allowlist + policy gives the right behaviour without per-invocation prompts.

This mirrors the existing treatment of `Bash(git checkout *)`, which is already allowed despite having an equivalently destructive `git checkout .` form gated by the same policy rule.

Closes dotfiles-csi.

## Test plan

- [ ] CI green on this PR (markdownlint, actionlint, install matrix).
- [ ] After merge + `chezmoi apply`: `git switch <branch>` runs without a permission prompt in a fresh Claude Code session.