### PR TITLE
chore(gitignore): add .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ Thumbs.db
 # Project-local Claude Code settings (machine-specific permissions, never shared)
 .claude/settings.local.json
 
+# Claude Code scheduled-task lock file (created by Monitor / ScheduleWakeup tools)
+.claude/scheduled_tasks.lock
+
 # Ignore shell history
 .zsh_history
 .bash_history


### PR DESCRIPTION
## Summary

Adds `.claude/scheduled_tasks.lock` to the repo root `.gitignore`, grouped with the existing `.claude/settings.local.json` entry. The file is created in working trees by Claude Code's `Monitor` / `ScheduleWakeup` tools and is machine-local state, not source.

From retro 2026-04-18 PENDING.

Closes dotfiles-oce.

## Test plan

- [ ] CI green on this PR.