### PR TITLE
docs(claude): foreground all bd operations in /bd-import-github-issues

### DIFF
--- a/home/dot_claude/commands/bd-import-github-issues.md
+++ b/home/dot_claude/commands/bd-import-github-issues.md
@@ -16,7 +16,7 @@ Run at the start of a session when the GitHub Issues tab on this repo has accumu
 ## Operational notes
 
 - Use `mcp__github__*` tools throughout, not the `gh` CLI (per the user's global preference). Specifically: `mcp__github__list_issues`, `mcp__github__add_issue_comment`, `mcp__github__issue_write` (for closing).
-- Run all `bd create` calls synchronously in the foreground. Each is fast (~1 sec).
+- **Foreground all bd operations.** Don't background `bd dolt pull`, `bd dolt push`, or `bd create` calls. Each completes in <30 sec when the procedure is followed; backgrounding turns transient failures into polling rounds and adds 5+ minutes of overhead per attempt.
 - **Syncs the embedded Dolt DB.** Step 0 pulls before importing; Step 8 pushes after. Both are no-ops on projects without a Dolt remote configured. This keeps the command correct when run standalone — `/start-session` chains into it on yes-prompt, but invocation via either entry point lands beads in the same synced state.
 - Expected total runtime: 30 sec to 2 min for a typical batch of 1-10 issues.
 


### PR DESCRIPTION
## Summary

Promotes the existing "Run all `bd create` calls synchronously in the foreground" note in `bd-import-github-issues.md` to a stronger, broader guideline: **don't background any bd operation** — `bd dolt pull` (Step 0), `bd dolt push` (Step 8), or `bd create` calls. Mirrors the same guidance already in `/bd-modernize` v3 (line 22).

Why: backgrounding bd operations during the v1 dogfood turned transient failures into polling rounds and added 5+ minutes of overhead per attempt. This skill historically called it out for `bd create` only; the same logic applies to the dolt pull/push it now does.

From retro 2026-04-18 PENDING.

Closes dotfiles-fv7.

## Test plan

- [ ] CI green on this PR (markdown lint).