### PR TITLE
docs(claude): /end-session step 3 — print failing CI URL inline

### DIFF
--- a/home/dot_claude/commands/end-session.md
+++ b/home/dot_claude/commands/end-session.md
@@ -61,7 +61,7 @@ Folded into step 1's gather. The `fetch` section contains the output. If its exi
 
 From gather section `main_ci`. Parse the most recent run per workflow:
 
-- **Failed**: flag loudly with workflow name + URL. A red `main` is the loudest "not clean" signal.
+- **Failed**: flag loudly with `<workflow name>: <full run URL>` on its own line so the user can click straight through. The gather script already returns the URL in `main_ci` — print it inline; don't make the user chase it with a follow-up `gh run view`. A red `main` is the loudest "not clean" signal.
 - **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
 - **All green**: silent.
 
@@ -178,7 +178,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Branches pruned (squash-merged): `<list or "none">`
 - Stashed/committed work this run: `<describe or "none">`
 - Main rebased: `<yes/no, behind/ahead counts>`
-- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow names>>`
+- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL>>`
 - Open PRs needing action: `<count by category, or "none">`
 - Stashes outstanding: `<count, or "none">`
 - Beads in_progress (yours): `<count, or "none">`


### PR DESCRIPTION
## Summary

Two doc tweaks to `home/dot_claude/commands/end-session.md` so a failing `main` CI is reported with the run URL inline (no follow-up `gh run view` needed):

- Step 3 wording — require `<workflow name>: <full run URL>` on its own line. The gather script already returns the URL; this just makes the consumption explicit.
- Phase 1 summary format — change the `FAILED:` slot from "workflow names" to "workflow name + run URL".

## Companion retro item (already done — no change)

The 2026-04-21 retro item to "tighten squash-merge branch detection" is already implemented in `~/.claude/bin/end-session-squash-merged`:

```bash
git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/ \
    | awk '$2 ~ /gone/ { print $1 }' \
    | grep -vE '^(main|master)$' \
    | while read -r branch; do
        git diff --quiet main.."$branch" 2>/dev/null && echo "$branch"
      done
```

Matches the retro spec exactly (`upstream:track gone` + empty diff vs main → safe `-D`). Step 6 Batch B in `end-session.md` already calls this script.

Retro 2026-04-27 PENDING (CI URL part).

Closes dotfiles-d71.

## Test plan

- [ ] CI green on this PR (markdownlint).
- [ ] Next `/end-session` run with a failing `main` CI prints the run URL inline next to the workflow name.