### PR TITLE
feat(zsh): rename 'dotbrew' to 'brewup'

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You don't need to remember chezmoi or brew incantations:
 - **`dotup`** — pull latest dotfiles, update Oh My Zsh + plugins, refresh
   nano syntax, update Starship (Linux) and Rust toolchain, then reload
   aliases/functions in the current shell
-- **`dotbrew`** — `brew update` + install everything in your Brewfile +
+- **`brewup`** — `brew update` + install everything in your Brewfile +
   `brew upgrade`, in one step
 - **`dotclaude`** — interactive Claude Code MCP server setup (GitHub MCP
   wired to your `gh` auth token, Google Developer Knowledge keyed from
@@ -151,7 +151,7 @@ run `chezmoi apply`.
 
 ```bash
 dotup                 # Pull latest dotfiles + update OMZ, plugins, Starship, Rust
-dotbrew               # brew update + install Brewfile + brew upgrade
+brewup                # brew update + install Brewfile + brew upgrade
 dotclaude             # Interactive Claude Code MCP server setup
 dotstatus             # Machine type, source path, last applied, pending changes
 dotfuncs              # List all custom shell functions with descriptions

--- a/cspell.json
+++ b/cspell.json
@@ -10,6 +10,7 @@
     "Bitwarden",
     "Bonjour",
     "Brewfiles",
+    "brewup",
     "catppuccin",
     "chezmoi",
     "chezmoiignore",

--- a/docs/adrs/0005-brewfile-canonical-macos-packages.md
+++ b/docs/adrs/0005-brewfile-canonical-macos-packages.md
@@ -21,11 +21,11 @@ Macos packages live exclusively in `home/Brewfile.tmpl`.
 
 - `Brewfile.tmpl` is templated by chezmoi and renders to `~/Brewfile` per
   the active machine type (personal / work / minimal).
-- `dotbrew` runs `brew update`, `brew bundle install --file ~/Brewfile`,
+- `brewup` runs `brew update`, `brew bundle install --file ~/Brewfile`,
   then `brew upgrade` — the daily refresh path.
 - `run_once_after_install-brewfile.sh.tmpl` runs the bundle install on the
   first `chezmoi apply`, so a fresh machine bootstraps the full package set
-  without manual intervention. Ongoing updates run through `dotbrew`.
+  without manual intervention. Ongoing updates run through `brewup`.
 - apt and winget lists do not duplicate Homebrew formulae.
 
 ## Consequences
@@ -33,7 +33,7 @@ Macos packages live exclusively in `home/Brewfile.tmpl`.
 ### Positive
 
 - One file to edit when adding or removing macOS packages.
-- `dotbrew` always picks up the latest list with no chezmoi reapply.
+- `brewup` always picks up the latest list with no chezmoi reapply.
 - `brew bundle dump` round-trips cleanly into the same format.
 - Templated tier branches keep personal / work / minimal in one place.
 

--- a/docs/adrs/0009-helper-shell-functions.md
+++ b/docs/adrs/0009-helper-shell-functions.md
@@ -30,7 +30,7 @@ under `home/dot_config/zsh/functions/`, autoloaded by the shell.
 | Function | Purpose |
 | -------- | ------- |
 | `dotup` | Pull dotfiles, refresh Oh My Zsh + plugins, update Starship (Linux) + Rust toolchain, reload aliases/functions in the current shell. |
-| `dotbrew` | `brew update` + `brew bundle install` against `~/Brewfile` + `brew upgrade`. |
+| `brewup` | `brew update` + `brew bundle install` against `~/Brewfile` + `brew upgrade`. (Was `dotbrew`; renamed for clarity. `dotbrew` remains as a one-cycle deprecation alias that prints a notice and forwards.) |
 | `dotclaude` | Interactive Claude Code MCP server setup (GitHub MCP from `gh` token, Google Developer Knowledge from Bitwarden). |
 | `dotstatus` | Print machine type, chezmoi source path, last applied time, and any pending diff. |
 | `dotfuncs` | List every custom function with its one-line description (self-documenting). |

--- a/home/dot_config/zsh/functions/brewup.zsh
+++ b/home/dot_config/zsh/functions/brewup.zsh
@@ -1,0 +1,26 @@
+#!/bin/zsh
+# shellcheck disable=SC1071
+# Update Homebrew, install everything in your Brewfile, then upgrade
+
+brewup() {
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Error: Homebrew is not installed."
+    return 1
+  fi
+
+  echo "==> Updating Homebrew..."
+  brew update
+
+  local brewfile="$HOME/Brewfile"
+  if [ -f "$brewfile" ]; then
+    echo "\n==> Installing packages from Brewfile..."
+    brew bundle install --file "$brewfile"
+  else
+    echo "Warning: Brewfile not found at $brewfile"
+  fi
+
+  echo "\n==> Upgrading installed packages..."
+  brew upgrade
+
+  echo "\n==> Homebrew packages up to date."
+}

--- a/home/dot_config/zsh/functions/dotbrew.zsh
+++ b/home/dot_config/zsh/functions/dotbrew.zsh
@@ -1,26 +1,8 @@
 #!/bin/zsh
 # shellcheck disable=SC1071
-# Install and upgrade Homebrew packages from Brewfile
+# Deprecated alias — 'dotbrew' was renamed to 'brewup'. Remove after one release cycle
 
 dotbrew() {
-  if ! command -v brew >/dev/null 2>&1; then
-    echo "Error: Homebrew is not installed."
-    return 1
-  fi
-
-  echo "==> Updating Homebrew..."
-  brew update
-
-  local brewfile="$HOME/Brewfile"
-  if [ -f "$brewfile" ]; then
-    echo "\n==> Installing packages from Brewfile..."
-    brew bundle install --file "$brewfile"
-  else
-    echo "Warning: Brewfile not found at $brewfile"
-  fi
-
-  echo "\n==> Upgrading installed packages..."
-  brew upgrade
-
-  echo "\n==> Homebrew packages up to date."
+  echo "==> 'dotbrew' has been renamed to 'brewup' — running brewup; update your muscle memory." >&2
+  brewup "$@"
 }

--- a/home/dot_config/zsh/functions/dotclaude.zsh
+++ b/home/dot_config/zsh/functions/dotclaude.zsh
@@ -26,7 +26,7 @@ dotclaude() {
     read -r answer
     if [ "$answer" = "y" ]; then
       if ! command -v github-mcp-server >/dev/null 2>&1; then
-        echo "Warning: github-mcp-server not found — run 'dotbrew' first"
+        echo "Warning: github-mcp-server not found — run 'brewup' first"
       elif ! command -v gh >/dev/null 2>&1; then
         echo "Warning: gh CLI not found — skipping GitHub MCP"
       else

--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Install Homebrew packages from Brewfile on first run
-# Subsequent updates are handled manually via 'dotbrew'
+# Subsequent updates are handled manually via 'brewup'
 
 set -e
 

--- a/home/run_once_remove-claude-code-cask.sh
+++ b/home/run_once_remove-claude-code-cask.sh
@@ -7,7 +7,7 @@
 # Runs exactly once per machine via chezmoi's run_once_ prefix.
 # Idempotent: no-op on Linux, fresh installs, or already-migrated machines.
 #
-# After this script removes the legacy cask, the next 'dotbrew' run will
+# After this script removes the legacy cask, the next 'brewup' run will
 # install 'claude-code@latest' from the updated Brewfile.
 
 set -eu
@@ -29,5 +29,5 @@ fi
 if brew list --cask claude-code >/dev/null 2>&1; then
   echo "==> Removing legacy 'claude-code' cask (replaced by 'claude-code@latest' in Brewfile)..."
   brew uninstall --cask claude-code
-  echo "==> Done. Run 'dotbrew' to install claude-code@latest from the updated Brewfile."
+  echo "==> Done. Run 'brewup' to install claude-code@latest from the updated Brewfile."
 fi


### PR DESCRIPTION
## Summary

`brewup` more accurately describes what the function does (brew update + bundle install + upgrade pipeline). The `dot*` prefix is conceptually for "dotfiles maintenance" helpers (`dotup`, `dotstatus`, `dotfuncs`, `dotclaude`); a brew-update step doesn't really fit that family.

## Changes

- **New**: `home/dot_config/zsh/functions/brewup.zsh` — the renamed function (identical semantics).
- **Backwards-compat**: `home/dot_config/zsh/functions/dotbrew.zsh` kept as a one-cycle deprecation alias that prints a notice and forwards to `brewup`:

  ```
  dotbrew() {
    echo "==> 'dotbrew' has been renamed to 'brewup' — running brewup; update your muscle memory." >&2
    brewup "$@"
  }
  ```

  Both files coexist for now (chezmoi doesn't auto-remove files dropped from source). A follow-up PR after one release cycle should delete `dotbrew.zsh`.

- **Updated references** (every dotbrew mention outside the deprecation alias):
  - `README.md` — daily-helpers list + reference table
  - `docs/adrs/0005-brewfile-canonical-macos-packages.md` — 3 mentions
  - `docs/adrs/0009-helper-shell-functions.md` — table row + deprecation note
  - `home/dot_config/zsh/functions/dotclaude.zsh` — `Warning: ... run 'dotbrew' first` → `'brewup' first`
  - `home/run_once_after_install-brewfile.sh.tmpl` — top-of-file comment
  - `home/run_once_remove-claude-code-cask.sh` — 2 mentions

- **`cspell.json`**: added `brewup`; kept `dotbrew` (deprecation alias still references it).

Closes dotfiles-nes.

## Test plan

- [ ] CI green (markdownlint, shellcheck, install matrix).
- [ ] After merge + `chezmoi apply`: both `brewup` and `dotbrew` work; `dotbrew` prints the deprecation notice + forwards.