### PR TITLE
feat(starship): show full path (not repo-truncated) in prompt directory

### DIFF
--- a/home/dot_config/starship.toml
+++ b/home/dot_config/starship.toml
@@ -48,6 +48,13 @@ style = "fg:#20b664"
 format = "[$path]($style)[$read_only]($read_only_style) "
 truncation_length = 3
 truncation_symbol = "…/"
+# Show the path from cwd, not from the git-repo root, so sibling checkouts of
+# the same repo name (e.g. ~/dev/dotfiles vs /tmp/jacks-dot/.dotfiles) are
+# distinguishable in the prompt. With truncation_length=3 this gives:
+#   ~/dev/dotfiles               → ~/dev/dotfiles
+#   /tmp/jacks-dot/.dotfiles     → …/tmp/jacks-dot/.dotfiles
+#   ~/dev/some/deep/nested/path  → …/some/deep/nested/path
+truncate_to_repo = false
 
 [git_branch]
 symbol = ""


### PR DESCRIPTION
## Summary

Starship's `directory` module defaults to `truncate_to_repo=true`, which collapses the displayed path to the repo root once you're inside one. Result: `~/dev/dotfiles` and `/tmp/jacks-dot/.dotfiles` both render as the bare `dotfiles` segment in the prompt, hiding which checkout you're in.

Setting `truncate_to_repo=false` makes the existing `truncation_length=3` take effect uniformly:

| pwd | Old display | New display |
|---|---|---|
| `~/dev/dotfiles` | `dotfiles` | `~/dev/dotfiles` |
| `/tmp/jacks-dot/.dotfiles` | `.dotfiles` | `…/tmp/jacks-dot/.dotfiles` |
| `~/dev/some/deep/nested/path` | depends on the repo root | `…/some/deep/nested/path` |
| `~/Downloads` (non-repo) | `~/Downloads` | `~/Downloads` (unchanged) |

The 2-line prompt has plenty of width to absorb the extra context.

Closes dotfiles-18n.

## Test plan

- [ ] CI green.
- [ ] After merge + `chezmoi apply`: prompt in `~/dev/dotfiles`, `/tmp/jacks-dot/.dotfiles`, and a non-repo dir reads as expected per the table above.