### PR TITLE
refactor(zsh): move 'rustup update' from dotup to brewup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Zsh + Oh My Zsh with quality-of-life add-ons:
 You don't need to remember chezmoi or brew incantations:
 
 - **`dotup`** — pull latest dotfiles, update Oh My Zsh + plugins, refresh
-  nano syntax, update Starship (Linux) and Rust toolchain, then reload
-  aliases/functions in the current shell
+  nano syntax, update Starship (Linux), then reload aliases/functions in
+  the current shell
 - **`brewup`** — `brew update` + install everything in your Brewfile +
-  `brew upgrade`, in one step
+  `brew upgrade` + `rustup update`, in one step
 - **`dotclaude`** — interactive Claude Code MCP server setup (GitHub MCP
   wired to your `gh` auth token, Google Developer Knowledge keyed from
   Bitwarden)
@@ -150,8 +150,8 @@ run `chezmoi apply`.
 ### Daily helpers
 
 ```bash
-dotup                 # Pull latest dotfiles + update OMZ, plugins, Starship, Rust
-brewup                # brew update + install Brewfile + brew upgrade
+dotup                 # Pull latest dotfiles + update OMZ, plugins, Starship
+brewup                # brew update + install Brewfile + brew upgrade + rustup update
 dotclaude             # Interactive Claude Code MCP server setup
 dotstatus             # Machine type, source path, last applied, pending changes
 dotfuncs              # List all custom shell functions with descriptions

--- a/docs/adrs/0009-helper-shell-functions.md
+++ b/docs/adrs/0009-helper-shell-functions.md
@@ -11,7 +11,7 @@ several multi-step incantations that nobody remembers off the top of
 their head:
 
 - Pull the latest dotfiles, refresh Oh My Zsh and its plugins, update
-  Starship and Rust, reload functions in the current shell.
+  Starship, reload functions in the current shell.
 - Update Homebrew, install everything declared in the Brewfile, then
   upgrade.
 - Configure Claude Code MCP servers with the right credentials.
@@ -29,8 +29,8 @@ under `home/dot_config/zsh/functions/`, autoloaded by the shell.
 
 | Function | Purpose |
 | -------- | ------- |
-| `dotup` | Pull dotfiles, refresh Oh My Zsh + plugins, update Starship (Linux) + Rust toolchain, reload aliases/functions in the current shell. |
-| `brewup` | `brew update` + `brew bundle install` against `~/Brewfile` + `brew upgrade`. (Was `dotbrew`; renamed for clarity. `dotbrew` remains as a one-cycle deprecation alias that prints a notice and forwards.) |
+| `dotup` | Pull dotfiles, refresh Oh My Zsh + plugins, update Starship (Linux), reload aliases/functions in the current shell. |
+| `brewup` | `brew update` + `brew bundle install` against `~/Brewfile` + `brew upgrade` + `rustup update` (rust toolchain isn't in the Brewfile but is a package-manager update). (Was `dotbrew`; renamed for clarity. `dotbrew` remains as a one-cycle deprecation alias that prints a notice and forwards.) |
 | `dotclaude` | Interactive Claude Code MCP server setup (GitHub MCP from `gh` token, Google Developer Knowledge from Bitwarden). |
 | `dotstatus` | Print machine type, chezmoi source path, last applied time, and any pending diff. |
 | `dotfuncs` | List every custom function with its one-line description (self-documenting). |

--- a/home/dot_config/zsh/functions/brewup.zsh
+++ b/home/dot_config/zsh/functions/brewup.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # shellcheck disable=SC1071
-# Update Homebrew, install everything in your Brewfile, then upgrade
+# Update Homebrew + Brewfile, then any non-brew package managers (rustup)
 
 brewup() {
   if ! command -v brew >/dev/null 2>&1; then
@@ -22,5 +22,13 @@ brewup() {
   echo "\n==> Upgrading installed packages..."
   brew upgrade
 
-  echo "\n==> Homebrew packages up to date."
+  # Rust isn't in the Brewfile (rustup manages its own toolchain channel),
+  # but it IS a package-manager update, which is brewup's remit. Belongs
+  # here, not in dotup.
+  if command -v rustup >/dev/null 2>&1; then
+    echo "\n==> Updating Rust toolchain..."
+    rustup update
+  fi
+
+  echo "\n==> Packages up to date."
 }

--- a/home/dot_config/zsh/functions/dotup.zsh
+++ b/home/dot_config/zsh/functions/dotup.zsh
@@ -30,11 +30,6 @@ dotup() {
     curl -sS https://starship.rs/install.sh | sh -s -- -y
   fi
 
-  if command -v rustup >/dev/null 2>&1; then
-    echo "\n==> Updating Rust toolchain..."
-    rustup update
-  fi
-
   echo "\n==> Reloading shell aliases and functions..."
   # shellcheck source=/dev/null
   [ -f "$HOME/.config/zsh/aliases.zsh" ] && source "$HOME/.config/zsh/aliases.zsh"


### PR DESCRIPTION
## Summary

Per the original framing in GitHub issue #170: `dotup` is for refreshing dotfiles + shell-config plugins; it shouldn't be installing or updating binaries. Rust is a package-manager update — same shape as `brew upgrade` — and belongs in `brewup`.

This also makes the new function-family split (`dotup` = dotfiles state, `brewup` = package state) tidier — the rename in PR #190 set up the conceptual boundary; this PR honours it.

## Changes

- `home/dot_config/zsh/functions/brewup.zsh` — append `rustup update` after the brew block. Header comment + closing message updated to reflect the broader "package-manager update" remit.
- `home/dot_config/zsh/functions/dotup.zsh` — remove the rustup block.
- `README.md` (2 places) — update the daily-helpers list + reference table.
- `docs/adrs/0009-helper-shell-functions.md` (2 places) — Context section + decision table.

Closes dotfiles-ao7.

## Test plan

- [ ] CI green (markdownlint, shellcheck).
- [ ] After merge + `chezmoi apply`: `dotup` no longer touches rustup; `brewup` includes the rustup-update step at the end.