### PR TITLE
refactor(prompt): drop VSCODE_COPILOT_CHAT_TERMINAL guard around Starship init

### DIFF
--- a/docs/TRANSIENT-PROMPT.md
+++ b/docs/TRANSIENT-PROMPT.md
@@ -89,17 +89,6 @@ code so that `$PROMPT` and `$RPROMPT` are already set when they are
 captured. Both must happen **after** `source "$ZSH/oh-my-zsh.sh"` to avoid
 Oh My Zsh overwriting the prompt.
 
-### VS Code Copilot Chat terminal
-
-The entire Starship + transient prompt block is wrapped in a guard:
-
-```zsh
-if [ -z "$VSCODE_COPILOT_CHAT_TERMINAL" ] || [ "$VSCODE_COPILOT_CHAT_TERMINAL" != "1" ]; then
-```
-
-This prevents prompt issues in VS Code's Copilot Chat terminal, which
-manages its own prompt rendering.
-
 ## Configuration
 
 ### `starship.toml`

--- a/home/dot_config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/home/dot_config/powershell/Microsoft.PowerShell_profile.ps1
@@ -1,12 +1,10 @@
 # PowerShell Profile - Cross-platform configuration
 # This profile is managed by chezmoi and provides a consistent experience across Windows and WSL
 
-# Initialize Starship prompt (unless in VS Code Copilot Chat terminal)
-if ($env:VSCODE_COPILOT_CHAT_TERMINAL -ne "1") {
-    if (Get-Command starship -ErrorAction SilentlyContinue) {
-        $env:STARSHIP_CONFIG = "$HOME/.config/starship.toml"
-        Invoke-Expression (&starship init powershell)
-    }
+# Initialize Starship prompt
+if (Get-Command starship -ErrorAction SilentlyContinue) {
+    $env:STARSHIP_CONFIG = "$HOME/.config/starship.toml"
+    Invoke-Expression (&starship init powershell)
 }
 
 # Set PSReadLine options for better command line editing

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -157,25 +157,23 @@ if [ -d "$HOME/.config/zsh/functions" ]; then
 fi
 
 # Starship prompt (init after OMZ source to preserve transient prompt hooks)
-if [ -z "$VSCODE_COPILOT_CHAT_TERMINAL" ] || [ "$VSCODE_COPILOT_CHAT_TERMINAL" != "1" ]; then
-  export STARSHIP_CONFIG="$HOME/.config/starship.toml"
-  eval "$(starship init zsh)"
+export STARSHIP_CONFIG="$HOME/.config/starship.toml"
+eval "$(starship init zsh)"
 
-  # Transient prompt: collapse previous prompts to just the character symbol.
-  # See docs/TRANSIENT-PROMPT.md for details.
-  __starship_full_prompt=$PROMPT
-  __starship_full_rprompt=$RPROMPT
+# Transient prompt: collapse previous prompts to just the character symbol.
+# See docs/TRANSIENT-PROMPT.md for details.
+__starship_full_prompt=$PROMPT
+__starship_full_rprompt=$RPROMPT
 
-  __starship_transient_accept_line() {
-    PROMPT='$(starship module character)'
-    RPROMPT=''
-    zle reset-prompt
-    PROMPT=$__starship_full_prompt
-    RPROMPT=$__starship_full_rprompt
-    zle .accept-line
-  }
-  zle -N accept-line __starship_transient_accept_line
-fi
+__starship_transient_accept_line() {
+  PROMPT='$(starship module character)'
+  RPROMPT=''
+  zle reset-prompt
+  PROMPT=$__starship_full_prompt
+  RPROMPT=$__starship_full_rprompt
+  zle .accept-line
+}
+zle -N accept-line __starship_transient_accept_line
 
 # Optional machine-local overrides (not managed by chezmoi)
 # shellcheck source=/dev/null

--- a/scripts/validate-installation.sh
+++ b/scripts/validate-installation.sh
@@ -118,11 +118,10 @@ fi
 PROMPT_CHECK_FILE="/tmp/zsh_prompt_check_$(date +%s)"
 if [[ "$(uname -s)" == "Darwin" ]]; then
     # macOS syntax: script [file] [command]
-    # We clear VSCODE_COPILOT_CHAT_TERMINAL to ensure starship loads even if running from VS Code
-    script -q "$PROMPT_CHECK_FILE" env VSCODE_COPILOT_CHAT_TERMINAL="" zsh -ic "echo \"PROMPT=\$PROMPT\"" >/dev/null 2>&1
+    script -q "$PROMPT_CHECK_FILE" zsh -ic "echo \"PROMPT=\$PROMPT\"" >/dev/null 2>&1
 elif [[ "$(uname -s)" == "Linux" ]]; then
     # Linux syntax: script -c [command] [file]
-    script -q -c "env VSCODE_COPILOT_CHAT_TERMINAL='' zsh -ic 'echo \"PROMPT=\$PROMPT\"'" "$PROMPT_CHECK_FILE" >/dev/null 2>&1
+    script -q -c "zsh -ic 'echo \"PROMPT=\$PROMPT\"'" "$PROMPT_CHECK_FILE" >/dev/null 2>&1
 fi
 
 validate_test_pkg "Starship is hooked into Zsh PROMPT" "grep -F 'starship prompt' \"$PROMPT_CHECK_FILE\""
@@ -176,9 +175,9 @@ if command -v pwsh >/dev/null 2>&1; then
     # Verify Starship loads in PowerShell by capturing the prompt output
     PWSH_CHECK_FILE="/tmp/pwsh_check_$(date +%s)"
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        script -q "$PWSH_CHECK_FILE" env VSCODE_COPILOT_CHAT_TERMINAL="" pwsh -Command "prompt" >/dev/null 2>&1
+        script -q "$PWSH_CHECK_FILE" pwsh -Command "prompt" >/dev/null 2>&1
     elif [[ "$(uname -s)" == "Linux" ]]; then
-        script -q -c "env VSCODE_COPILOT_CHAT_TERMINAL='' pwsh -Command 'prompt'" "$PWSH_CHECK_FILE" >/dev/null 2>&1
+        script -q -c "pwsh -Command 'prompt'" "$PWSH_CHECK_FILE" >/dev/null 2>&1
     fi
     
     if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
## Summary

- The `VSCODE_COPILOT_CHAT_TERMINAL` env-var guard was a workaround for the pre-transient-prompt era, when Copilot Chat would parse terminal output and trip on Starship's full prompt.
- The transient prompt now collapses prior prompts to just the character symbol, so output parsing is no longer disrupted — the guard is dead code.
- Removes the guard from zsh + PowerShell init, drops the env-clearing dance from `validate-installation.sh`, and removes the now-orphaned section from `docs/TRANSIENT-PROMPT.md`.

Closes dotfiles-fmv (imported from #5).

## Test plan

- [ ] CI passes (ShellCheck + markdownlint + Test Install matrix)
- [ ] After merge + `dotup`, prompt still renders normally in a fresh zsh session
- [ ] PowerShell prompt still renders Starship symbol when `pwsh` is installed