### PR TITLE
feat(zshrc): use fd as FZF default source

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -131,6 +131,14 @@ if command -v zoxide >/dev/null 2>&1; then
   eval "$(zoxide init zsh)"
 fi
 
+# fzf: use fd as the file source so default ignores (.git, node_modules,
+# build dirs) apply to Ctrl-T file picker and fuzzy completion. fd is faster
+# than find and respects .gitignore by default.
+if command -v fd >/dev/null 2>&1; then
+  export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git --exclude node_modules --exclude .cache'
+  export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+fi
+
 # nvm (Node Version Manager)
 export NVM_DIR="$HOME/.nvm"
 # shellcheck disable=SC1091


### PR DESCRIPTION
## Summary

Closes dotfiles-3mv. First of the 7 candidate fzf/zoxide integrations from the bead — picked because it has the highest daily-use impact for the lowest setup cost and zero muscle-memory disruption.

Sets `FZF_DEFAULT_COMMAND` (and the Ctrl-T variant) to `fd`, so the fzf file picker:

- Skips `.git`, `node_modules`, `.cache` automatically
- Respects `.gitignore` (fd's default)
- Is noticeably faster than fzf's built-in find walk on large repos

`fd` is already in the Brewfile (personal + work tiers); the export is gated on `command -v fd` so a machine without it falls back to fzf's defaults.

## What was deferred (per the bead's "try one at a time" rule)

- `zoxide --cmd cd` — replaces `cd` entirely; muscle-memory disruption, not signalled as wanted
- `fzf-tab` — fzf-driven tab completion; another OMZ plugin to load
- `forgit` — fzf-driven git add/log/diff; new key-bindings to learn
- `FZF_CTRL_T_OPTS` preview pane with `bat` — natural follow-on once this soaks
- `lazygit` fzf integration — lazygit already has its own picker
- `FZF_DEFAULT_OPTS` theming — cosmetic

## Test plan

- [ ] CI passes (ShellCheck + markdownlint + Test Install matrix)
- [ ] After `dotup`: `echo $FZF_DEFAULT_COMMAND` shows the fd command
- [ ] In a large repo, Ctrl-T file picker is visibly faster and excludes `.git`/`node_modules`