### PR TITLE
docs(readme): document podman machine init as a first-run extra (macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ This installs chezmoi, packages (Homebrew/apt/winget), shell config (Zsh +
 Oh My Zsh or PowerShell), Starship prompt, git-delta, lazygit, tmux, VS Code
 settings, JetBrains Mono Nerd Font, and platform-specific defaults.
 
+## First-run extras (optional)
+
+A few one-time bootstrap steps that aren't auto-run on first apply because
+they're heavy or workflow-specific.
+
+### Container runtime (macOS only)
+
+The Brewfile installs `podman` + `podman-compose`, but on macOS the podman
+machine VM still needs to be initialised once before the CLI is usable:
+
+```bash
+podman machine init   # ~800 MB image download
+podman machine start
+podman info           # verify
+```
+
+Linux uses the host kernel directly — no `podman machine` step needed.
+
 ## Per-Platform Reference
 
 | | macOS | Linux / WSL | Windows |


### PR DESCRIPTION
## Summary

Closes dotfiles-tlz. The Brewfile installs `podman` + `podman-compose`, but on macOS the podman machine VM still needs `podman machine init && podman machine start` (~800 MB image download) before the CLI is usable. The bead asked: auto-run on apply, document only, or small helper function?

Decided **document only** — picked because:

- Adding a silent ~800 MB download to first `chezmoi apply` would be hostile when the user may not need containers immediately
- Existing chunky bootstrap steps that need user judgement (Bitwarden secrets, container runtime config) follow the same documented-not-auto-run pattern
- A helper function would muddle the responsibilities of the existing `dotup` / `brewup` family
- ADR-0008 already documents the rough edges of podman-machine on macOS; this is the natural companion

Adds a new "First-run extras (optional)" section right after Quick Start. Linux is explicitly noted as not needing the step.

If experience shows the manual step is more friction than expected, follow-up beads can add a small `podman-up` helper or a one-time `run_once_after_install-podman.sh.tmpl` — but starting minimal.

## Test plan

- [ ] CI passes (markdownlint)
- [ ] Doc renders correctly on GitHub