### PR TITLE
feat(aliases): make eza the default ls with common variants

### DIFF
--- a/home/dot_config/zsh/aliases.zsh
+++ b/home/dot_config/zsh/aliases.zsh
@@ -6,6 +6,15 @@
 
 # --- CLI tool defaults ---
 
+# eza: modern ls replacement
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza'
+  alias l='eza -l --git'
+  alias ll='eza -l --git'
+  alias la='eza -la --git'
+  alias lt='eza --tree --level=2'
+fi
+
 # bat: use as default pager and cat replacement
 if command -v bat >/dev/null 2>&1; then
   alias cat='bat --paging=never'


### PR DESCRIPTION
## Summary

Adds eza-backed aliases in `home/dot_config/zsh/aliases.zsh` so `ls` and friends use eza by default:

- `ls` → `eza`
- `l` / `ll` → `eza -l --git`
- `la` → `eza -la --git`
- `lt` → `eza --tree --level=2`

All aliases are guarded by `command -v eza`, matching the existing `bat` and `podman` patterns in the same file — systems without eza (fresh Ubuntu/Windows installs) keep the stock `ls`. eza is already pulled in by `Brewfile.tmpl` on macOS/Linux, so the macOS/Linux brew path gets these aliases automatically.

Refs: dotfiles-9j9

## Test plan

- [ ] `chezmoi apply` (or `dotup`) and confirm `type ls` reports the alias
- [ ] `ls`, `ll`, `la`, `lt` render with eza output
- [ ] Spot-check that `command -v eza` guard means a non-eza shell doesn't break (e.g. `PATH=/usr/bin:/bin zsh -ic 'type ls'`)