### PR TITLE
feat(dotup): always refresh chezmoi externals

### DIFF
--- a/home/dot_config/zsh/functions/dotup.zsh
+++ b/home/dot_config/zsh/functions/dotup.zsh
@@ -4,7 +4,11 @@
 
 dotup() {
   echo "==> Updating dotfiles..."
-  PAGER=cat chezmoi update -v
+  # --refresh-externals forces chezmoi externals (e.g. agentic-coding-config
+  # mounted at ~/.claude/) to re-fetch, bypassing their refreshPeriod. Cheap
+  # for small repos and the user is always online during dotup, so the
+  # always-latest semantics are worth the extra ~1s.
+  PAGER=cat chezmoi update -v --refresh-externals
 
   if [ -d "$ZSH" ]; then
     echo "\n==> Updating Oh My Zsh..."


### PR DESCRIPTION
## Summary

After the `agentic-coding-config` split (#203), `~/.claude/` is sourced from a chezmoi external whose `refreshPeriod = "168h"`. That means edits to `agentic-coding-config` (slash commands, settings, hooks) require either waiting up to a week, or manually running `chezmoi update --refresh-externals`, before they land on the local machine.

Since I iterate `agentic-coding-config` frequently and am always online during `dotup`, `--refresh-externals` is the right default for the human-facing command.

## Change

One line in `home/dot_config/zsh/functions/dotup.zsh`:

```diff
-  PAGER=cat chezmoi update -v
+  PAGER=cat chezmoi update -v --refresh-externals
```

Plus a comment explaining why.

## Why this approach (vs alternatives)

| Option | Verdict |
| --- | --- |
| **Lower `refreshPeriod` in `.chezmoiexternal.toml.tmpl`** | Affects every `chezmoi apply` (including CI). Less targeted. |
| **Track upstream commit hash and refresh only on change** | Bookkeeping > bandwidth. archive externals can't cheaply check upstream; a 1MB tarball download is ~1s. |
| **Always refresh in dotup (this PR)** | dotup is the human-facing "I want latest" command. refreshPeriod stays sensible for non-dotup invocations. ✓ |

## Test plan

- [ ] Merge
- [ ] `dotup` (the new function reloads itself; if not, `source ~/.config/zsh/functions/dotup.zsh`)
- [ ] Verify `head -1 ~/.claude/commands/retrospective.md` shows the new opening line ("Run a retrospective on this session and route findings...") — confirming the latest agentic-coding-config tarball was fetched

Closes `dotfiles-mv5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)