### PR TITLE
feat(node): add npm-globals install pattern with @google/clasp

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ brew bundle
 # home/.chezmoi.toml.tmpl; the rendered ~/.config/ubuntu_pkglist
 # regenerates from it, and changes auto-install on the next apply.
 chezmoi init --apply
+
+# npm globals — declared under [data.packages.npm] in
+# home/.chezmoi.toml.tmpl. run_onchange_after_install-npm-globals
+# sources nvm, ensures NodeJS LTS is installed, then `npm install -g`
+# each entry. Re-runs whenever the list changes.
 ```
 
 ## Secret Management

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -166,6 +166,18 @@
             packages_pinned = []
 {{- end }}
 
+        # npm - global packages installed via npm install -g
+        # Requires nvm (already in Brewfile for macOS personal/work).
+        # Install pattern: home/run_onchange_after_install-npm-globals.sh.tmpl
+        [data.packages.npm]
+{{- if eq $machineType "personal" }}
+            packages = [
+                "@google/clasp",
+            ]
+{{- else }}
+            packages = []
+{{- end }}
+
     # VS Code extensions - organized by scope
     [data.vscode]
         # Core extensions — installed on work and personal machines

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -28,6 +28,8 @@ run_once_macos_defaults.sh
 macos_defaults.sh
 run_once_after_install-brewfile.sh
 install-brewfile.sh
+run_onchange_after_install-npm-globals.sh
+install-npm-globals.sh
 run_once_remove-claude-code-cask.sh
 remove-claude-code-cask.sh
 run_onchange_install-ubuntu-packages.sh

--- a/home/run_onchange_after_install-npm-globals.sh.tmpl
+++ b/home/run_onchange_after_install-npm-globals.sh.tmpl
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Install global npm packages declared in .chezmoi.toml.tmpl under
+# [data.packages.npm]. Re-runs whenever the rendered package list changes
+# (run_onchange contract). Sequenced after run_once_after_install-brewfile so
+# brew-installed nvm is present on a fresh macOS box.
+
+set -e
+
+{{- if eq (env "DOTFILES_SKIP_INSTALL") "1" }}
+echo "DOTFILES_SKIP_INSTALL=1 — skipping npm-globals install (fast CI mode)"
+exit 0
+{{- end }}
+
+case "$(uname -s)" in
+  Darwin*|Linux*) ;;
+  *)
+    echo "Not Darwin/Linux — skipping npm-globals install"
+    exit 0
+    ;;
+esac
+
+{{ $pkgs := .packages.npm.packages -}}
+{{- if eq (len $pkgs) 0 }}
+echo "No npm globals declared for this machine — skipping"
+exit 0
+{{- else }}
+
+# Source nvm from common locations. Brew installs nvm but does not auto-source.
+NVM_SH=""
+for candidate in \
+  "/opt/homebrew/opt/nvm/nvm.sh" \
+  "/usr/local/opt/nvm/nvm.sh" \
+  "$HOME/.nvm/nvm.sh"; do
+  if [ -s "$candidate" ]; then
+    NVM_SH="$candidate"
+    break
+  fi
+done
+
+if [ -z "$NVM_SH" ]; then
+  echo "ERROR: nvm not found in /opt/homebrew/opt/nvm, /usr/local/opt/nvm, or \$HOME/.nvm"
+  echo "Install nvm first (macOS: 'brew install nvm'; otherwise see https://github.com/nvm-sh/nvm)"
+  exit 1
+fi
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+mkdir -p "$NVM_DIR"
+# shellcheck source=/dev/null
+. "$NVM_SH"
+
+echo "Ensuring NodeJS LTS is installed via nvm..."
+nvm install --lts
+nvm use --lts
+
+echo "Installing npm global packages..."
+{{ range $pkgs }}
+echo "  -> {{ . }}"
+npm install -g "{{ . }}"
+{{- end }}
+
+echo "npm-globals install complete."
+{{- end }}


### PR DESCRIPTION
## Summary

- Introduces a third package-management pattern alongside Brewfile and the apt/winget lists: npm globals declared in `.chezmoi.toml.tmpl` under `[data.packages.npm]`, installed by a `run_onchange` script that ensures NodeJS LTS via nvm and runs `npm install -g` per entry. Re-fires whenever the list changes.
- First entry: `@google/clasp` (the motivating ask, GH#206 / `dotfiles-r6d`). No brew formula exists for Google's clasp, so this gap is exactly what npm-globals fills.
- README updated under "Package management" to mention the new pattern + nvm prerequisite.

## Design notes

- Script naming: `run_onchange_after_install-npm-globals.sh.tmpl`. The `_after_` qualifier and alphabetic ordering put it after `run_once_after_install-brewfile.sh.tmpl`, so brew-installed nvm exists on a fresh macOS box before this script tries to source it.
- Run-onchange (not run-once) so list edits trigger reinstall — the package list is inlined via Go template, so any `[data.packages.npm].packages` change re-renders the script with a different content hash and re-fires.
- `nvm install --lts` and `npm install -g` are both idempotent, so re-runs are cheap.
- Personal machine_type only for v1; `work` and `minimal` get an empty list and the script short-circuits with a "no globals declared — skipping" message.
- macOS + Linux only. Windows handled separately if/when needed (winget already provides Node, so a `.ps1.tmpl` analog would be the path forward — deferred to a future bead).
- Does **not** auto-install nvm. Brewfile already provides it on macOS personal/work; if missing, the script fails fast with a clear error rather than `curl | bash` an external installer.

## Test plan

- [x] `chezmoi execute-template` renders the script cleanly for `personal` (with `@google/clasp`)
- [x] `chezmoi execute-template` renders the "no globals declared" branch for `work` / `minimal`
- [x] Rendered shell passes `shellcheck`
- [x] `markdownlint-cli2 README.md` passes
- [x] `chezmoi init --apply` against a clean `HOME` runs end-to-end with `DOTFILES_SKIP_INSTALL=1`
- [ ] On the real machine: `dotup`, then `command -v clasp` returns a path; `node --version` shows LTS
- [ ] Edit the npm list (add a throwaway pkg), re-run dotup, confirm it re-fires; revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)