### PR TITLE
feat(dotup): silence Oh My Zsh upgrade banner and social plugs

### DIFF
--- a/home/dot_config/zsh/functions/dotup.zsh
+++ b/home/dot_config/zsh/functions/dotup.zsh
@@ -12,7 +12,9 @@ dotup() {
 
   if [ -d "$ZSH" ]; then
     echo "\n==> Updating Oh My Zsh..."
-    "$ZSH/tools/upgrade.sh"
+    # -v silent: skip OMZ's ASCII-art banner and social-media plugs on success.
+    # Errors still surface; our own ==> header announces the section.
+    "$ZSH/tools/upgrade.sh" -v silent
   fi
 
   local plugin_dir="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins"


### PR DESCRIPTION
## Summary

- Pass `-v silent` to `$ZSH/tools/upgrade.sh` in `dotup`, suppressing the ASCII-art banner, "Hooray! Oh My Zsh has been updated!" message, "see the changelog with `omz changelog`" hint, and X/Discord/swag links that printed on every `dotup` invocation.
- ~11 lines of cosmetic noise per `dotup` removed. Errors still surface (the `silent` mode only suppresses success output). dotup's own `==> Updating Oh My Zsh...` header still announces the section, matching the pattern used for `zsh-autosuggestions`, `zsh-syntax-highlighting`, etc.

## Test plan

- [x] Verified `$HOME/.oh-my-zsh/tools/upgrade.sh -v silent` runs to exit 0 with no output on an already-updated repo
- [x] Inspected `upgrade.sh` source: error path (`There was an error updating. Try again later?` on line 282) is outside the verbose-mode guard, so failures still print
- [ ] After merge, run `dotup` locally to confirm the OMZ section is silent on no-op and that the next real OMZ update only shows our `==>` header
- [ ] CI: ShellCheck on `home/` (unchanged file already had pre-existing SC2028/SC2209 warnings; this PR adds none)

Closes dotfiles-872