### PR TITLE
fix(dotup): auto-recover when chezmoi config template is stale

### DIFF
--- a/home/dot_config/zsh/functions/dotup.zsh
+++ b/home/dot_config/zsh/functions/dotup.zsh
@@ -8,7 +8,22 @@ dotup() {
   # mounted at ~/.claude/) to re-fetch, bypassing their refreshPeriod. Cheap
   # for small repos and the user is always online during dotup, so the
   # always-latest semantics are worth the extra ~1s.
-  PAGER=cat chezmoi update -v --refresh-externals
+  local update_log
+  update_log=$(mktemp)
+  PAGER=cat chezmoi update -v --refresh-externals 2>&1 | tee "$update_log"
+
+  # Auto-recover when chezmoi warns the rendered ~/.config/chezmoi/chezmoi.toml
+  # is stale (typically: a new [data.*] block was added to .chezmoi.toml.tmpl
+  # since the user last ran init, so downstream templates referencing the new
+  # key fail with "map has no entry for key X"). Re-init re-uses stored
+  # promptChoiceOnce answers, so it's non-interactive.
+  if grep -q "config file template has changed" "$update_log"; then
+    echo "\n==> Config template changed — regenerating with 'chezmoi init'..."
+    chezmoi init
+    echo "\n==> Re-applying with refreshed config..."
+    PAGER=cat chezmoi apply -v
+  fi
+  rm -f "$update_log"
 
   if [ -d "$ZSH" ]; then
     echo "\n==> Updating Oh My Zsh..."


### PR DESCRIPTION
## Summary

- Detect chezmoi's `config file template has changed` warning in `dotup` and auto-run `chezmoi init` + `chezmoi apply` so the rendered `~/.config/chezmoi/chezmoi.toml` refreshes and the apply succeeds in the same invocation.
- Removes a footgun where adding a new `[data.*]` block to `home/.chezmoi.toml.tmpl` silently breaks `dotup` for existing users until they remember to manually re-init.

## Why

After PR #207 added `[data.packages.npm]`, users whose rendered config predated that PR saw:

```
chezmoi: warning: config file template has changed, run chezmoi init to regenerate config file
chezmoi: install-npm-globals.sh: template: ...: map has no entry for key "npm"
```

`dotup` is the user-friendly wrapper; it shouldn't push recovery onto the user when chezmoi already tells us exactly what to do. `chezmoi init` is safe to auto-run here because the only prompt in the template is `promptChoiceOnce` for `machine_type`, which re-uses the stored answer.

## Test plan

- [ ] Run `dotup` on a machine where the rendered config is up-to-date → no auto-init branch fires, output matches prior behaviour.
- [ ] Simulate stale config (delete `[data.packages.npm]` from `~/.config/chezmoi/chezmoi.toml`, run `dotup`) → warning is captured, `chezmoi init` runs non-interactively, `chezmoi apply -v` succeeds, npm-globals script renders correctly.
- [ ] `zsh -n home/dot_config/zsh/functions/dotup.zsh` — syntax OK.

Closes dotfiles-u4m

🤖 Generated with [Claude Code](https://claude.com/claude-code)