### PR TITLE
fix(brew): set HOMEBREW_NO_ASK=1 for unattended installs

### DIFF
--- a/home/dot_config/zsh/functions/brewup.zsh
+++ b/home/dot_config/zsh/functions/brewup.zsh
@@ -14,13 +14,15 @@ brewup() {
   local brewfile="$HOME/Brewfile"
   if [ -f "$brewfile" ]; then
     echo "\n==> Installing packages from Brewfile..."
-    brew bundle install --file "$brewfile"
+    # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts;
+    # brewup's whole point is unattended install/upgrade
+    HOMEBREW_NO_ASK=1 brew bundle install --file "$brewfile"
   else
     echo "Warning: Brewfile not found at $brewfile"
   fi
 
   echo "\n==> Upgrading installed packages..."
-  brew upgrade
+  HOMEBREW_NO_ASK=1 brew upgrade
 
   # Rust isn't in the Brewfile (rustup manages its own toolchain channel),
   # but it IS a package-manager update, which is brewup's remit. Belongs

--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -18,7 +18,8 @@ case "$(uname -s)" in
     BREWFILE="$HOME/Brewfile"
     if [ -f "$BREWFILE" ]; then
       echo "Installing Homebrew packages from Brewfile..."
-      HOMEBREW_BUNDLE_NO_LOCK=1 brew bundle install --file "$BREWFILE"
+      # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts
+      HOMEBREW_BUNDLE_NO_LOCK=1 HOMEBREW_NO_ASK=1 brew bundle install --file "$BREWFILE"
     else
       echo "Warning: Brewfile not found at $BREWFILE, skipping brew bundle"
     fi


### PR DESCRIPTION
## Summary

Homebrew 6 made **ask mode the default**: `brew upgrade` and `brew bundle`'s internal installs now prompt for confirmation unless `--yes`/`--no-ask` is passed or `$HOMEBREW_NO_ASK` is set:

```text
-y, --no-ask, --yes    Do not ask for confirmation before downloading and
                       upgrading. Ask mode is the default unless $HOMEBREW_NO_ASK is set.
```

This broke `brewup` (and the first-run Brewfile bootstrap), whose whole point is unattended install/upgrade.

## Changes

- `home/dot_config/zsh/functions/brewup.zsh` — prefix `brew bundle install` and `brew upgrade` with `HOMEBREW_NO_ASK=1`
- `home/run_once_after_install-brewfile.sh.tmpl` — same for the first-run bootstrap install (an interactive prompt there would stall new-machine provisioning)

Env-var prefix per invocation (matching the existing `HOMEBREW_BUNDLE_NO_LOCK=1` style) rather than a global export, so interactive `brew` use keeps the ask-mode default.

## Testing

- `shellcheck` passes on `brewup.zsh`; `.tmpl` warnings are pre-existing Go-template syntax already tolerated by CI
- Flag/env-var verified against `brew upgrade --help` on Homebrew 6.0.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)