### PR TITLE
fix(brew): make run_once brewfile bootstrap idempotent so dotup stops installing packages

### DIFF
--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -16,12 +16,22 @@ case "$(uname -s)" in
     eval "$(/opt/homebrew/bin/brew shellenv)"
 
     BREWFILE="$HOME/Brewfile"
-    if [ -f "$BREWFILE" ]; then
+    if [ ! -f "$BREWFILE" ]; then
+      echo "Warning: Brewfile not found at $BREWFILE, skipping brew bundle"
+    elif brew bundle check --file "$BREWFILE" >/dev/null 2>&1; then
+      # This is a run_once script, keyed by chezmoi on its content hash — so any
+      # edit to this file makes chezmoi re-run it on the next 'chezmoi apply'.
+      # Since 'dotup' calls 'chezmoi update' (= pull + apply), an unguarded
+      # install here would fire during dotup, breaking ADR-0005's rule that
+      # dotup never touches packages ('brewup' owns that). Guard on 'brew bundle
+      # check': an already-provisioned machine satisfies the Brewfile, so we
+      # skip and stay a no-op. Only a genuinely fresh machine (missing formulae)
+      # falls through to the install below.
+      echo "Homebrew packages already satisfy Brewfile — skipping (use 'brewup' to update)."
+    else
       echo "Installing Homebrew packages from Brewfile..."
       # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts
       HOMEBREW_BUNDLE_NO_LOCK=1 HOMEBREW_NO_ASK=1 brew bundle install --file "$BREWFILE"
-    else
-      echo "Warning: Brewfile not found at $BREWFILE, skipping brew bundle"
     fi
     ;;
   *)


### PR DESCRIPTION
## Problem

`dotup` was installing/upgrading Homebrew packages again, which contradicts ADR-0005 (dotup pulls dotfiles; `brewup` owns package install/upgrade).

Root cause: `dotup` runs `chezmoi update` (= `git pull` + `chezmoi apply`). The bootstrap script `home/run_once_after_install-brewfile.sh.tmpl` is a chezmoi **`run_once_`** script, keyed by the hash of its rendered content. PR #217 ("set HOMEBREW_NO_ASK=1") edited that file, changing its hash, so chezmoi treated it as a new script and re-ran `brew bundle install` during the next `dotup`.

The intent of #217 was only to make `brewup` unattended — the edit to the run_once bootstrap script was an unintended side effect that re-triggered a package install through `dotup`.

## Fix

Guard the bootstrap install behind `brew bundle check` so a content-hash re-run is a harmless no-op on an already-provisioned machine:

- **Fresh machine** → `brew bundle check` fails → installs once (bootstrap, as intended).
- **Already provisioned** → check passes → skips, even if a future edit re-triggers the run_once.

This closes the trap permanently: package install/upgrade lives only in `brewup`, and editing this file can no longer cause `dotup` to touch packages.

Note: because this commit also edits the run_once file, it will re-trigger once more on the next `dotup` — but now it hits the `brew bundle check` guard, finds everything satisfied, and skips.

## Testing

- `sh -n` passes on the rendered script (change adds only plain shell, no new template lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWcJBfkE6qKZzys1DyWasC)_