### PR TITLE
fix(brew): stop dotup upgrading packages, looping the bootstrap, and dumping diffs

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -3,7 +3,6 @@
 
 {{- if eq .machine_type "personal" }}
 tap "aws/tap"
-tap "homebrew-ffmpeg/ffmpeg"
 
 brew "actionlint"
 brew "aws-sam-cli"
@@ -28,7 +27,7 @@ brew "go-task"
 brew "go"
 brew "golangci-lint"
 brew "gradle"
-brew "homebrew-ffmpeg/ffmpeg/ffmpeg"
+brew "ffmpeg"
 brew "hugo"
 brew "imagemagick"
 brew "jenv"

--- a/home/dot_config/zsh/functions/dotup.zsh
+++ b/home/dot_config/zsh/functions/dotup.zsh
@@ -8,9 +8,14 @@ dotup() {
   # mounted at ~/.claude/) to re-fetch, bypassing their refreshPeriod. Cheap
   # for small repos and the user is always online during dotup, so the
   # always-latest semantics are worth the extra ~1s.
+  # No -v: verbose mode prints the full unified diff of every changed file,
+  # which buries the run in noise on each dotup. Without it, chezmoi applies
+  # quietly and git's own pull summary still reports what came in. The
+  # "config file template has changed" warning below is a warning, not verbose
+  # output, so it still surfaces and the recovery path keeps working.
   local update_log
   update_log=$(mktemp)
-  PAGER=cat chezmoi update -v --refresh-externals 2>&1 | tee "$update_log"
+  PAGER=cat chezmoi update --refresh-externals 2>&1 | tee "$update_log"
 
   # Auto-recover when chezmoi warns the rendered ~/.config/chezmoi/chezmoi.toml
   # is stale (typically: a new [data.*] block was added to .chezmoi.toml.tmpl
@@ -21,7 +26,7 @@ dotup() {
     echo "\n==> Config template changed — regenerating with 'chezmoi init'..."
     chezmoi init
     echo "\n==> Re-applying with refreshed config..."
-    PAGER=cat chezmoi apply -v
+    PAGER=cat chezmoi apply
   fi
   rm -f "$update_log"
 

--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -18,20 +18,29 @@ case "$(uname -s)" in
     BREWFILE="$HOME/Brewfile"
     if [ ! -f "$BREWFILE" ]; then
       echo "Warning: Brewfile not found at $BREWFILE, skipping brew bundle"
-    elif brew bundle check --file "$BREWFILE" >/dev/null 2>&1; then
+    elif brew bundle check --no-upgrade --file "$BREWFILE" >/dev/null 2>&1; then
       # This is a run_once script, keyed by chezmoi on its content hash — so any
       # edit to this file makes chezmoi re-run it on the next 'chezmoi apply'.
       # Since 'dotup' calls 'chezmoi update' (= pull + apply), an unguarded
       # install here would fire during dotup, breaking ADR-0005's rule that
-      # dotup never touches packages ('brewup' owns that). Guard on 'brew bundle
-      # check': an already-provisioned machine satisfies the Brewfile, so we
-      # skip and stay a no-op. Only a genuinely fresh machine (missing formulae)
-      # falls through to the install below.
+      # dotup never touches packages ('brewup' owns that).
+      #
+      # --no-upgrade is load-bearing: without it 'brew bundle check' returns
+      # non-zero when any package is merely OUTDATED (not just missing), so a
+      # fully-provisioned machine with stale packages would fail the guard and
+      # fall through to install — silently upgrading everything during dotup.
+      # With --no-upgrade the guard tests presence only: a provisioned machine
+      # passes and stays a no-op. Only a genuinely fresh machine (missing
+      # formulae) falls through to the install below.
       echo "Homebrew packages already satisfy Brewfile — skipping (use 'brewup' to update)."
     else
       echo "Installing Homebrew packages from Brewfile..."
-      # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts
-      HOMEBREW_BUNDLE_NO_LOCK=1 HOMEBREW_NO_ASK=1 brew bundle install --file "$BREWFILE"
+      # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts.
+      # HOMEBREW_BUNDLE_NO_UPGRADE=1: install missing formulae only, leave
+      # already-present-but-outdated packages alone — 'brewup' owns upgrades
+      # (ADR-0005), so even the fresh-install path must not upgrade.
+      HOMEBREW_BUNDLE_NO_LOCK=1 HOMEBREW_NO_ASK=1 HOMEBREW_BUNDLE_NO_UPGRADE=1 \
+        brew bundle install --file "$BREWFILE"
     fi
     ;;
   *)


### PR DESCRIPTION
## Why

`dotup` was upgrading Homebrew packages on every run, dumping ugly output, and re-running the brew bootstrap script forever. Three fixes, two root-cause bugs plus the output noise:

1. **Guard tested currency, not presence.** `brew bundle check` only exits 0 when everything is present *and up to date*. With any outdated package the guard fell through to `brew bundle install`, upgrading everything — violating ADR-0005 (dotup never touches packages).
2. **Untrusted ffmpeg tap looped the run_once.** `homebrew-ffmpeg/ffmpeg/ffmpeg` couldn&#39;t install unattended (`Refusing to load formula ... from untrusted tap`), so the script exited 1. chezmoi only records a `run_once_` script on exit 0, so it re-ran on every apply/dotup.
3. **`chezmoi update -v` dumped a full file diff every run** (e.g. the +35-line script diff), burying the run in noise.

## What

- `brew bundle check --no-upgrade` — guard tests presence only.
- `HOMEBREW_BUNDLE_NO_UPGRADE=1` on the install path — even a fresh install leaves present-but-outdated packages for `brewup`.
- Brewfile: `homebrew-ffmpeg/ffmpeg/ffmpeg` (+ tap) → core `ffmpeg`, which installs unattended everywhere.
- `dotup.zsh`: drop `-v` from `chezmoi update` (and the recovery-path `chezmoi apply`). chezmoi now applies quietly; git's pull summary still reports what came in, and the "config file template has changed" warning that drives the re-init recovery still surfaces (it's a warning, not verbose output).

## Verification

- Rendered brew template and `dotup.zsh` pass `shellcheck` clean.
- Confirmed the failure mechanism live on the affected machine: `brew bundle check` exit 1 with 30 outdated packages; `homebrew-ffmpeg/ffmpeg/ffmpeg` not installed due to untrusted tap; core `ffmpeg` 8.1.2 available.

Closes #340