### PR TITLE
feat(brew): add xcodegen to personal macOS Brewfile

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -59,6 +59,7 @@ brew "uv"
 brew "watch"
 brew "weasyprint"
 brew "wget"
+brew "xcodegen"
 brew "yq"
 brew "zoxide"
 


### PR DESCRIPTION
Adds `brew "xcodegen"` to the personal section of `home/Brewfile.tmpl` for generating Xcode projects on macOS. Placed alphabetically between `wget` and `yq`. Personal profile only, per request.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)