### PR TITLE
feat(brew): add xcodes to personal macOS Brewfile

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -60,6 +60,7 @@ brew "watch"
 brew "weasyprint"
 brew "wget"
 brew "xcodegen"
+brew "xcodes"
 brew "yq"
 brew "zoxide"
 


### PR DESCRIPTION
Adds `brew "xcodes"` to the personal section of `home/Brewfile.tmpl`, alphabetically after `xcodegen`.

**Why not Xcode directly:** Xcode has no Homebrew cask — it ships via the Mac App Store. The `xcodes` formula is a version manager that downloads Xcode from Apple and supports side-by-side versions.

**Follow-up required:** installing Xcode itself stays manual (`xcodes install --latest`) because it prompts for Apple ID authentication and can't run unattended in the bootstrap.

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)