### PR TITLE
feat(brew): add aria2 to personal macOS Brewfile

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -5,6 +5,7 @@
 tap "aws/tap"
 
 brew "actionlint"
+brew "aria2"
 brew "aws-sam-cli"
 brew "awscli"
 brew "azure-cli"


### PR DESCRIPTION
Adds `brew "aria2"` to the personal section of `home/Brewfile.tmpl`, alphabetically between `actionlint` and `aws-sam-cli`.

`xcodes` (added in #345) detects aria2 on PATH automatically and uses it to download Xcode with up to 16 parallel connections — roughly 3-5x faster. No configuration needed; it's opt-out via `--no-aria2` rather than opt-in.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)