### PR TITLE
refactor(shell): codify &lt;tool&gt;up naming convention for helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ You don't need to remember chezmoi or brew incantations:
   the current shell
 - **`brewup`** — `brew update` + install everything in your Brewfile +
   `brew upgrade` + `rustup update`, in one step
-- **`dotclaude`** — interactive Claude Code MCP server setup (GitHub MCP
+- **`claudeup`** — interactive Claude Code MCP server setup (GitHub MCP
   wired to your `gh` auth token, Google Developer Knowledge keyed from
   Bitwarden)
+- **`xcodeup`** — macOS only: install/update the latest Xcode via
+  `xcodes`, point the toolchain at it, and report simulator runtimes.
+  Interactive — Apple sign-in can't be automated
 - **`dotstatus`** — machine type, source path, last applied, and any
   pending changes
 - **`dotfuncs`** — list every custom function with its one-line description
@@ -176,7 +179,8 @@ run `chezmoi apply`.
 ```bash
 dotup                 # Pull latest dotfiles + update OMZ, plugins, Starship
 brewup                # brew update + install Brewfile + brew upgrade + rustup update
-dotclaude             # Interactive Claude Code MCP server setup
+claudeup              # Interactive Claude Code MCP server setup
+xcodeup               # macOS: install/select latest Xcode via xcodes
 dotstatus             # Machine type, source path, last applied, pending changes
 dotfuncs              # List all custom shell functions with descriptions
 ```

--- a/docs/adrs/0009-helper-shell-functions.md
+++ b/docs/adrs/0009-helper-shell-functions.md
@@ -1,7 +1,11 @@
 # ADR-0009: Helper shell functions for daily dotfiles workflow
 
 - **Status**: Accepted
-- **Date**: 2026-04-26
+- **Date**: 2026-04-26 (amended 2026-07-19: naming rule made explicit,
+  `dotclaude` → `claudeup`, `xcodeup` added, `dotbrew` alias removed)
+- **Note**: deprecation aliases are only warranted for everyday commands.
+  `dotbrew` got one because `brewup` runs constantly; `dotclaude` did not,
+  because it runs once per machine build.
 - **Tags**: shell, dx
 
 ## Context
@@ -24,14 +28,27 @@ somewhere. The previous repo had only a few ad-hoc helpers (e.g.
 
 ## Decision
 
-Define a small set of `dot*` and `note*` zsh functions, one per file,
-under `home/dot_config/zsh/functions/`, autoloaded by the shell.
+Define a small set of zsh functions, one per file, under
+`home/dot_config/zsh/functions/`, autoloaded by the shell.
+
+Naming follows one rule, by scope of effect:
+
+- **`dot*`** — acts on the dotfiles/chezmoi system itself
+  (`dotup`, `dotstatus`, `dotfuncs`).
+- **`<tool>up`** — brings a specific third-party tool current on this
+  machine (`brewup`, `claudeup`, `xcodeup`).
+
+The original set used `dot*` for everything, which made the prefix a
+vanity namespace rather than a meaningful signal: `dotbrew` never
+touched dotfiles, it managed Homebrew. Renaming it to `brewup`
+established the split above, and `dotclaude` → `claudeup` completes it.
 
 | Function | Purpose |
 | -------- | ------- |
 | `dotup` | Pull dotfiles, refresh Oh My Zsh + plugins, update Starship (Linux), reload aliases/functions in the current shell. |
-| `brewup` | `brew update` + `brew bundle install` against `~/Brewfile` + `brew upgrade` + `rustup update` (rust toolchain isn't in the Brewfile but is a package-manager update). (Was `dotbrew`; renamed for clarity. `dotbrew` remains as a one-cycle deprecation alias that prints a notice and forwards.) |
-| `dotclaude` | Interactive Claude Code MCP server setup (GitHub MCP from `gh` token, Google Developer Knowledge from Bitwarden). |
+| `brewup` | `brew update` + `brew bundle install` against `~/Brewfile` + `brew upgrade` + `rustup update` (rust toolchain isn't in the Brewfile but is a package-manager update). |
+| `claudeup` | Interactive Claude Code MCP server setup (GitHub MCP from `gh` token, Google Developer Knowledge from Bitwarden). (Was `dotclaude`; renamed outright with no deprecation alias — it runs once per machine build, so there is no muscle memory to protect.) |
+| `xcodeup` | macOS only. Install/update the latest Xcode via `xcodes`, select the toolchain, and report simulator runtime status. Interactive — Apple ID sign-in cannot be automated. |
 | `dotstatus` | Print machine type, chezmoi source path, last applied time, and any pending diff. |
 | `dotfuncs` | List every custom function with its one-line description (self-documenting). |
 | `note` / `n` | Append a timestamped bullet to `~/notes/<project>.md` (project = git repo basename or cwd basename). `note -e` opens it in `$EDITOR`. |
@@ -47,7 +64,8 @@ reloaded individually. `dotfuncs` is the entry point for discovery.
 - Memorable, short commands replace multi-step incantations.
 - One file per function keeps the shell config tidy and easy to lint.
 - `dotfuncs` keeps the helper set discoverable without external docs.
-- The `dot*` prefix makes them easy to grep and to tab-complete.
+- The prefix now carries meaning: `dot*` signals "touches my dotfiles",
+  `<tool>up` signals "touches that tool" — readable without the docs.
 
 ### Negative / trade-offs
 

--- a/docs/adrs/0010-secrets-management.md
+++ b/docs/adrs/0010-secrets-management.md
@@ -22,7 +22,7 @@ The current state of the repo blends two approaches:
   `~/.config/chezmoi/key.txt` from a secure store before
   `chezmoi init --apply`.
 - The `personal` Brewfile already installs `bitwarden-cli` and the
-  Bitwarden cask. The `dotclaude` helper reads the Google Developer
+  Bitwarden cask. The `claudeup` helper reads the Google Developer
   Knowledge API key from Bitwarden at MCP setup time. Beads
   `dotfiles-7r3` was closed with "Superseded by Bitwarden approach".
 
@@ -35,7 +35,7 @@ two have not been reconciled.
 Lean towards **Bitwarden as the source of truth for human-managed
 credentials**, including the seed needed to bootstrap a fresh machine.
 
-- `dotclaude` already pulls the Google Developer Knowledge MCP key from
+- `claudeup` already pulls the Google Developer Knowledge MCP key from
   Bitwarden. Extend the same pattern to any other API key the run scripts
   need.
 - Keep `age` available as an option for files that genuinely need to

--- a/home/dot_config/zsh/functions/claudeup.zsh
+++ b/home/dot_config/zsh/functions/claudeup.zsh
@@ -2,14 +2,14 @@
 # shellcheck disable=SC1071
 # Configure Claude Code MCP servers (interactive, personal machines only)
 
-dotclaude() {
+claudeup() {
   if ! command -v claude >/dev/null 2>&1; then
     echo "Error: Claude Code CLI is not installed."
     return 1
   fi
 
   if [ ! -t 0 ]; then
-    echo "Error: dotclaude requires an interactive shell."
+    echo "Error: claudeup requires an interactive shell."
     return 1
   fi
 
@@ -58,7 +58,7 @@ dotclaude() {
     read -r answer
     if [ "$answer" = "y" ]; then
       local dk_key
-      dk_key="$(_dotclaude_bw_get "claude-mcp-google-developer-knowledge-api-key")"
+      dk_key="$(_claudeup_bw_get "claude-mcp-google-developer-knowledge-api-key")"
       if [ -z "$dk_key" ]; then
         echo "Warning: could not retrieve API key — skipping Google Developer Knowledge MCP"
       else
@@ -76,8 +76,8 @@ dotclaude() {
   echo "Run 'claude mcp list' to verify."
 }
 
-# Helper: retrieve a secret from Bitwarden (unlocks once per dotclaude run)
-_dotclaude_bw_get() {
+# Helper: retrieve a secret from Bitwarden (unlocks once per claudeup run)
+_claudeup_bw_get() {
   local item_name="$1"
 
   if ! command -v bw >/dev/null 2>&1; then

--- a/home/dot_config/zsh/functions/dotbrew.zsh
+++ b/home/dot_config/zsh/functions/dotbrew.zsh
@@ -1,8 +1,0 @@
-#!/bin/zsh
-# shellcheck disable=SC1071
-# Deprecated alias — 'dotbrew' was renamed to 'brewup'. Remove after one release cycle
-
-dotbrew() {
-  echo "==> 'dotbrew' has been renamed to 'brewup' — running brewup; update your muscle memory." >&2
-  brewup "$@"
-}

--- a/home/dot_config/zsh/functions/xcodeup.zsh
+++ b/home/dot_config/zsh/functions/xcodeup.zsh
@@ -1,0 +1,59 @@
+#!/bin/zsh
+# shellcheck disable=SC1071
+# Install/update Xcode via xcodes, select the toolchain, report simulator runtimes
+
+xcodeup() {
+  if [ "$(uname -s)" != "Darwin" ]; then
+    echo "Error: xcodeup is macOS-only."
+    return 1
+  fi
+
+  if ! command -v xcodes >/dev/null 2>&1; then
+    echo "Error: xcodes not found — run 'brewup' first."
+    return 1
+  fi
+
+  # Xcode downloads come from Apple and need an Apple ID + 2FA, so this
+  # can never run unattended the way brewup does.
+  if [ ! -t 0 ]; then
+    echo "Error: xcodeup requires an interactive shell (Apple ID sign-in)."
+    return 1
+  fi
+
+  if ! command -v aria2c >/dev/null 2>&1; then
+    echo "Note: aria2 not installed — download will be 3-5x slower."
+    echo "      'brewup' installs it from the Brewfile."
+  fi
+
+  echo "==> Currently installed Xcode versions:"
+  xcodes installed || echo "  (none)"
+
+  echo "\n==> Refreshing available version list..."
+  xcodes update
+
+  # xcodes no-ops if the latest release is already installed. --select points
+  # xcode-select at it either way, which is the part that silently stays on
+  # CommandLineTools otherwise.
+  echo "\n==> Installing latest Xcode (prompts for Apple ID)..."
+  if ! xcodes install --latest --select --experimental-unxip; then
+    echo "Error: Xcode install failed."
+    return 1
+  fi
+
+  echo "\n==> Active toolchain: $(xcode-select -p)"
+
+  # A fresh Xcode ships with no simulator runtimes; they are a separate
+  # multi-GB download. Report rather than auto-install — most work does
+  # not need them and the download is large.
+  local runtimes
+  runtimes="$(xcrun simctl list runtimes 2>/dev/null | grep -c '^iOS\|^watchOS\|^tvOS\|^visionOS')"
+  if [ "$runtimes" -eq 0 ]; then
+    echo "\nNote: no simulator runtimes installed."
+    echo "      Install one with: xcodes runtimes install \"iOS 26.5\""
+    echo "      List available:   xcodes runtimes"
+  else
+    echo "\n==> ${runtimes} simulator runtime(s) installed."
+  fi
+
+  echo "\n==> Xcode up to date."
+}


### PR DESCRIPTION
## The rule

ADR-0009 originally used `dot*` for every helper, which made the prefix a vanity namespace rather than a signal — `dotbrew` never touched dotfiles, it managed Homebrew. That's why renaming it to `brewup` felt better. This PR writes the resulting rule down and applies it consistently:

- **`dot*`** — acts on the dotfiles/chezmoi system itself (`dotup`, `dotstatus`, `dotfuncs`)
- **`<tool>up`** — brings a third-party tool current on this machine (`brewup`, `claudeup`, `xcodeup`)

## Changes

| Change | Notes |
|---|---|
| Remove `dotbrew` | Its own comment said "remove after one release cycle"; that's elapsed. `dotfuncs` auto-discovers from the directory, so no listing update needed. |
| `dotclaude` → `claudeup` | **No deprecation alias** — unlike `brewup`, this runs once per machine build, so there's no muscle memory to protect. Internal helper renamed `_dotclaude_bw_get` → `_claudeup_bw_get`. |
| Add `xcodeup` | macOS-only. Runs `xcodes update`, installs latest with `--select --experimental-unxip`, reports simulator runtime status. |
| ADR-0009 | Naming rule documented; table updated; amendment note added. |
| ADR-0010 | Two live `dotclaude` references updated to `claudeup`. |
| README | Helper list and quick-reference updated. |

## On xcodeup

It deliberately does **not** try to be unattended like `brewup` — Xcode downloads require Apple ID sign-in with 2FA, so it guards on `[ -t 0 ]` and fails fast in a non-interactive shell. It also warns if `aria2` is missing (3-5x slower downloads) and reports rather than auto-installs simulator runtimes, since those are a separate multi-GB download most work doesn't need.

The `--select` step matters: a fresh Xcode install leaves `xcode-select` pointing at `/Library/Developer/CommandLineTools`, which fails confusingly later.

## Verification

- `shellcheck` clean on all function files
- `markdownlint-cli2` clean on README and both ADRs
- Functions load and define correctly under zsh; `xcodeup` non-interactive guard fires and returns 1 without side effects
- No lingering `dotbrew`/`dotclaude` references outside intentional historical mentions in ADR-0009

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)