### PR TITLE
feat(shell): download iOS platform in xcodeup; group dotfuncs output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ You don't need to remember chezmoi or brew incantations:
   wired to your `gh` auth token, Google Developer Knowledge keyed from
   Bitwarden)
 - **`xcodeup`** — macOS only: install/update the latest Xcode via
-  `xcodes`, point the toolchain at it, and report simulator runtimes.
-  Interactive — Apple sign-in can't be automated
+  `xcodes`, point the toolchain at it, and download the iOS platform
+  (simulator runtime). Interactive — Apple sign-in can't be automated
 - **`dotstatus`** — machine type, source path, last applied, and any
   pending changes
 - **`dotfuncs`** — list every custom function with its one-line description

--- a/docs/adrs/0009-helper-shell-functions.md
+++ b/docs/adrs/0009-helper-shell-functions.md
@@ -48,9 +48,9 @@ established the split above, and `dotclaude` → `claudeup` completes it.
 | `dotup` | Pull dotfiles, refresh Oh My Zsh + plugins, update Starship (Linux), reload aliases/functions in the current shell. |
 | `brewup` | `brew update` + `brew bundle install` against `~/Brewfile` + `brew upgrade` + `rustup update` (rust toolchain isn't in the Brewfile but is a package-manager update). |
 | `claudeup` | Interactive Claude Code MCP server setup (GitHub MCP from `gh` token, Google Developer Knowledge from Bitwarden). (Was `dotclaude`; renamed outright with no deprecation alias — it runs once per machine build, so there is no muscle memory to protect.) |
-| `xcodeup` | macOS only. Install/update the latest Xcode via `xcodes`, select the toolchain, and report simulator runtime status. Interactive — Apple ID sign-in cannot be automated. |
+| `xcodeup` | macOS only. Install/update the latest Xcode via `xcodes`, select the toolchain, and download the iOS platform (simulator runtime). Interactive — Apple ID sign-in cannot be automated. |
 | `dotstatus` | Print machine type, chezmoi source path, last applied time, and any pending diff. |
-| `dotfuncs` | List every custom function with its one-line description (self-documenting). |
+| `dotfuncs` | List every custom function with its one-line description (self-documenting), grouped into `*up` update commands and everything else. |
 | `note` / `n` | Append a timestamped bullet to `~/notes/<project>.md` (project = git repo basename or cwd basename). `note -e` opens it in `$EDITOR`. |
 | `notes` | List all note files, or grep across them. |
 

--- a/home/dot_config/zsh/functions/dotfuncs.zsh
+++ b/home/dot_config/zsh/functions/dotfuncs.zsh
@@ -3,7 +3,7 @@
 # List the custom shell functions installed by these dotfiles
 
 dotfuncs() {
-  local dir file name desc
+  local dir
   dir="$HOME/.config/zsh/functions"
 
   if [ ! -d "$dir" ]; then
@@ -11,11 +11,27 @@ dotfuncs() {
     return 1
   fi
 
-  echo "Custom shell functions available:"
+  echo "Update commands:"
+  _dotfuncs_list "$dir" up
+  echo "\nOther commands:"
+  _dotfuncs_list "$dir" other
+}
+
+# Helper: print one group of functions. Mode 'up' selects the *up commands
+# (the "bring something current" family); 'other' selects everything else.
+_dotfuncs_list() {
+  local dir="$1" mode="$2" file name desc
+
   for file in "$dir"/*.zsh; do
     [ -f "$file" ] || continue
     name="${file##*/}"
     name="${name%.zsh}"
+
+    case "$name" in
+      *up) [ "$mode" = "up" ]   || continue ;;
+      *)   [ "$mode" = "other" ] || continue ;;
+    esac
+
     # First comment line after the shebang and shellcheck pragma.
     desc=$(awk '
       /^#!/          { next }

--- a/home/dot_config/zsh/functions/xcodeup.zsh
+++ b/home/dot_config/zsh/functions/xcodeup.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # shellcheck disable=SC1071
-# Install/update Xcode via xcodes, select the toolchain, report simulator runtimes
+# Install/update Xcode via xcodes, select the toolchain, download the iOS platform
 
 xcodeup() {
   if [ "$(uname -s)" != "Darwin" ]; then
@@ -43,17 +43,17 @@ xcodeup() {
   echo "\n==> Active toolchain: $(xcode-select -p)"
 
   # A fresh Xcode ships with no simulator runtimes; they are a separate
-  # multi-GB download. Report rather than auto-install — most work does
-  # not need them and the download is large.
+  # multi-GB download. xcodebuild no-ops when the platform is already
+  # current, so this is safe to run on every invocation.
+  echo "\n==> Downloading iOS platform (simulator runtime)..."
+  if ! xcodebuild -downloadPlatform iOS; then
+    echo "Warning: iOS platform download failed."
+    echo "         Retry with: xcodebuild -downloadPlatform iOS"
+  fi
+
   local runtimes
   runtimes="$(xcrun simctl list runtimes 2>/dev/null | grep -c '^iOS\|^watchOS\|^tvOS\|^visionOS')"
-  if [ "$runtimes" -eq 0 ]; then
-    echo "\nNote: no simulator runtimes installed."
-    echo "      Install one with: xcodes runtimes install \"iOS 26.5\""
-    echo "      List available:   xcodes runtimes"
-  else
-    echo "\n==> ${runtimes} simulator runtime(s) installed."
-  fi
+  echo "\n==> ${runtimes} simulator runtime(s) installed."
 
   echo "\n==> Xcode up to date."
 }


### PR DESCRIPTION
Two follow-ups to #348.

## 1. `xcodeup` downloads the iOS platform

Replaces the report-only runtime block with an actual `xcodebuild -downloadPlatform iOS`. A fresh Xcode ships with zero simulator runtimes, so the previous behaviour left you one manual step short of a usable setup.

`xcodebuild` no-ops when the platform is already current, so it's safe on every invocation. A failure warns and prints the retry command rather than aborting — the Xcode install itself has already succeeded by that point and shouldn't be reported as failed.

## 2. `dotfuncs` groups its listing

`dotup` prints `dotfuncs` on completion, and it was a flat list. Now split by whether the command ends in `up`:

```
Update commands:
  brewup      Update Homebrew + Brewfile, then any non-brew package managers (rustup)
  claudeup    Configure Claude Code MCP servers (interactive, personal machines only)
  dotup       Update dotfiles and plugins (does not install/upgrade packages)
  xcodeup     Install/update Xcode via xcodes, select the toolchain, download the iOS platform

Other commands:
  dotfuncs    List the custom shell functions installed by these dotfiles
  dotstatus   Show dotfiles status: machine type, last applied, pending changes
  note        Quick project-scoped notes (also: notes, n alias)
```

Grouping stays auto-discovering — a new `*up` function lands in the right section with no edit here. Listing logic moved to a `_dotfuncs_list` helper, matching the `_claudeup_bw_get` pattern already in the repo.

## Verification

- `shellcheck` clean across all function files
- `markdownlint-cli2` clean on README and ADR-0009
- `dotfuncs` output verified in an isolated `HOME` (output above is real, not illustrative)
- `xcodeup` non-interactive guard still fires and returns 1 without side effects
- ADR-0009 and README descriptions updated to match the new behaviour

**Not verified:** the `-downloadPlatform` path itself has not been run end-to-end — it needs an interactive session and a multi-GB download. Flag existence confirmed against `xcodebuild -help`.

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)