### PR TITLE
fix(shell): silence xcodes catalogue dump in xcodeup

### DIFF
--- a/home/dot_config/zsh/functions/xcodeup.zsh
+++ b/home/dot_config/zsh/functions/xcodeup.zsh
@@ -28,8 +28,10 @@ xcodeup() {
   echo "==> Currently installed Xcode versions:"
   xcodes installed || echo "  (none)"
 
+  # 'xcodes update' dumps the entire catalogue (every Xcode back to 1.0) to
+  # stdout. Only the refresh matters here; stderr stays open for real errors.
   echo "\n==> Refreshing available version list..."
-  xcodes update
+  xcodes update >/dev/null
 
   # xcodes no-ops if the latest release is already installed. --select points
   # xcode-select at it either way, which is the part that silently stays on


### PR DESCRIPTION
`xcodes update` prints its entire catalogue — every Xcode release back to 1.0 (7B85) — to stdout, burying everything useful `xcodeup` says.

One-line fix: `xcodes update >/dev/null`. Verified locally that the catalogue goes to **stdout**, so the redirect silences it completely while leaving stderr open for genuine failures.

Kept the `xcodes installed` output — that's a single line showing the current version and which one is selected, which is worth seeing.

Resulting output:

```
==> Currently installed Xcode versions:
26.6 (17F113) [Apple Silicon] (Selected)	/Applications/Xcode-26.6.0.app

==> Refreshing available version list...

==> Installing latest Xcode (prompts for Apple ID)...
...
```

## Verification

- Confirmed the dump is stdout, not stderr, by running `xcodes update >/dev/null` and observing empty output
- `shellcheck` clean
- Non-interactive guard still fires and returns 1

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)