### PR TITLE
feat(shell): show open GitHub issue/PR counts in cship statusline

### DIFF
--- a/home/dot_config/cship.toml
+++ b/home/dot_config/cship.toml
@@ -8,7 +8,7 @@
 
 [cship]
 lines = [
-  "$directory$git_branch$git_status",
+  "$directory$git_branch$git_status$custom.gh_issues$custom.gh_prs",
   "$cship.model $cship.context_bar"
 ]
 

--- a/home/dot_config/starship.toml
+++ b/home/dot_config/starship.toml
@@ -101,6 +101,25 @@ format = "[ $version](fg:#AE1401) "
 [rust]
 format = "[ $version](fg:#CE412B) "
 
+# gh_issues / gh_prs are rendered only by cship (statusline passthrough) —
+# the prompt `format` above deliberately omits $custom so the shell prompt
+# never runs them. Counts come from a cached helper; see gh-statusline-counts.
+[custom.gh_issues]
+command = "~/.local/bin/gh-statusline-counts issues"
+when = "~/.local/bin/gh-statusline-counts issues"
+shell = ["sh"]
+symbol = " "
+style = "fg:#e0af68"
+format = "[$symbol$output]($style) "
+
+[custom.gh_prs]
+command = "~/.local/bin/gh-statusline-counts prs"
+when = "~/.local/bin/gh-statusline-counts prs"
+shell = ["sh"]
+symbol = " "
+style = "fg:#bb9af7"
+format = "[$symbol$output]($style) "
+
 #[aws]
 #symbol = ""
 #format = '[$symbol ($profile@$region)]($style) '

--- a/home/dot_local/bin/executable_gh-statusline-counts
+++ b/home/dot_local/bin/executable_gh-statusline-counts
@@ -1,0 +1,82 @@
+#!/bin/sh
+# gh-statusline-counts — open GitHub issue/PR counts for the current repo.
+#
+# Backs the [custom.gh_issues] / [custom.gh_prs] Starship modules rendered by
+# cship (see ~/.config/cship.toml). Prints a bare count and exits 0, or prints
+# nothing and exits 1 when the count is zero, the cwd isn't a GitHub repo, gh
+# is missing/unauthenticated, or no value has been fetched yet. The exit code
+# drives the modules' `when` clause, so a hidden module renders no symbol.
+#
+# Never blocks on the network: cship re-renders every few seconds, so cached
+# values (fresh or stale) are served immediately and refreshed in a background
+# subprocess at most once per TTL.
+#
+# Usage: gh-statusline-counts issues|prs
+
+set -u
+
+TTL=300
+LOCK_TTL=60
+
+field="${1:-}"
+case "$field" in
+  issues | prs) ;;
+  *)
+    echo "usage: gh-statusline-counts issues|prs" >&2
+    exit 2
+    ;;
+esac
+
+command -v gh >/dev/null 2>&1 || exit 1
+command -v git >/dev/null 2>&1 || exit 1
+
+url="$(git remote get-url origin 2>/dev/null)" || exit 1
+slug="$(printf '%s\n' "$url" | sed -n 's#.*github\.com[:/]\([^/][^/]*\)/\([^/][^/]*\)$#\1/\2#p')"
+slug="${slug%.git}"
+[ -n "$slug" ] || exit 1
+owner="${slug%%/*}"
+name="${slug##*/}"
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/gh-statusline"
+cache="$cache_dir/$owner-$name"
+mkdir -p "$cache_dir" || exit 1
+
+file_age() {
+  # Seconds since last modification; BSD stat then GNU stat.
+  mtime="$(stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null)" || mtime=0
+  echo "$(($(date +%s) - mtime))"
+}
+
+refresh() {
+  lock="$cache.lock"
+  if ! mkdir "$lock" 2>/dev/null; then
+    # A concurrent refresh holds the lock; reap it only if abandoned.
+    [ "$(file_age "$lock")" -gt "$LOCK_TTL" ] && rmdir "$lock" 2>/dev/null
+    return 0
+  fi
+  trap 'rmdir "$lock" 2>/dev/null' EXIT
+  # shellcheck disable=SC2016  # $owner/$name are GraphQL variables, not shell
+  counts="$(gh api graphql \
+    -F owner="$owner" -F name="$name" \
+    -f query='query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          issues(states: OPEN) { totalCount }
+          pullRequests(states: OPEN) { totalCount }
+        }
+      }' \
+    --jq '"issues=\(.data.repository.issues.totalCount)\nprs=\(.data.repository.pullRequests.totalCount)"' \
+    2>/dev/null)" || return 0
+  printf '%s\n' "$counts" >"$cache.tmp.$$" && mv "$cache.tmp.$$" "$cache"
+}
+
+if [ ! -f "$cache" ] || [ "$(file_age "$cache")" -gt "$TTL" ]; then
+  (refresh >/dev/null 2>&1 &)
+fi
+
+[ -f "$cache" ] || exit 1
+val="$(sed -n "s/^$field=//p" "$cache")"
+case "$val" in
+  '' | *[!0-9]*) exit 1 ;;
+  0) exit 1 ;;
+esac
+printf '%s' "$val"


### PR DESCRIPTION
Closes #359

Adds the repo's open-issue and open-PR counts to the cship git row:

```text
~/dev/dotfiles  feat/cship-gh-counts !2?1  13  2
  Sonnet ░░░░░░░░░░6%
```

## Changes

- **`home/dot_local/bin/executable_gh-statusline-counts`** (new) — POSIX sh helper printing a bare count for `issues` or `prs`. One GraphQL query fetches both counts; per-repo cache under `~/.cache/gh-statusline/` with 5-min TTL and stale-while-revalidate (cached value served immediately, background refresh behind a mkdir lock), so statusline renders never block on the network — the hot path measures ~20ms. Exits non-zero when there's nothing to show.
- **`home/dot_config/starship.toml`** — `[custom.gh_issues]` / `[custom.gh_prs]` modules. The `when` clause reuses the script's exit code, so the modules hide entirely (no stray symbol) at zero count, in non-GitHub dirs, or when `gh` is missing/unauthenticated. The shell prompt is unaffected — the top-level `format` deliberately omits `$custom`, so these only render via cship passthrough.
- **`home/dot_config/cship.toml`** — appends the two tokens to the git row.

## Verified locally

- Warm render shows ` 13  2` for this repo; cship end-to-end render matches the mock above
- Zero count, non-repo dir, and cold cache all render nothing (no stray symbol)
- ShellCheck-clean; BSD/GNU `stat` both handled for Linux/WSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)