### PR TITLE
feat(brew): restore tflint via terraform-linters tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Zsh + Oh My Zsh with quality-of-life add-ons:
   `fzf`, `zoxide`
 - **Git + dev** — `gh`, `lazygit`, `pre-commit`, `gitleaks`
 - **Languages** — Go, .NET, OpenJDK + `jenv`, `nvm`, `uv` (Python), Rust
-- **Cloud / infra** — `gcloud`, `awscli`, `azure-cli`, `tenv`,
+- **Cloud / infra** — `gcloud`, `awscli`, `azure-cli`, `tenv` + `tflint`,
   `checkov`, `trivy`, `semgrep`, `podman`
 - **Personal-tier GUI apps** — VS Code, Ghostty, Bitwarden, Rectangle,
   Chrome, JetBrains Mono Nerd Font, Claude Desktop, and more

--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -3,6 +3,7 @@
 
 {{- if eq .machine_type "personal" }}
 tap "aws/tap"
+tap "terraform-linters/tap"
 
 brew "actionlint"
 brew "aria2"
@@ -83,6 +84,7 @@ cask "microsoft-office"
 cask "private-internet-access"
 cask "rectangle"
 cask "steam"
+cask "terraform-linters/tap/tflint"
 cask "visual-studio-code"
 cask "voiceink"
 cask "whatsapp"


### PR DESCRIPTION
## Summary

Restores `tflint` to the personal Brewfile block, now sourced from the official upstream tap.

`tflint` was removed from homebrew-core on 2026-05-13 (BUSL-1.1 license on vendored Terraform HCL code) and dropped from this repo in #212. The maintainers have since published their official tap, `terraform-linters/homebrew-tap`.

## Changes

- `home/Brewfile.tmpl` — add `tap "terraform-linters/tap"` alongside the existing `aws/tap` declaration in the personal block, and add the tflint install line in the personal block
- `README.md` — reinstate the `tflint` mention in the Cloud / infra tool list (line ~44)

## Note: cask, not formula

The upstream tap ships tflint as a **cask**, not a formula — so the install line differs from the old `brew "tflint"`:

```ruby
cask "terraform-linters/tap/tflint"
```

This matches the Brewfile line documented in the tap's README (the issue anticipated a `brew` formula line, but the tap went the cask route).

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)