### PR TITLE
ci(shellcheck): actually lint zsh functions in CI; de-zsh-ify echo escapes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
         with:
-          scandir: './scripts ./home'
+          # scandir is a single directory (the action passes it to find as one
+          # quoted path — './scripts ./home' made find fail and lint nothing).
+          # Scan the repo root: the action's own find picks up *.sh and *.zsh
+          # and excludes .git; .tmpl files never match, so templates are skipped.
+          scandir: '.'
 
   markdown-lint:
     name: Markdown Lint

--- a/home/dot_config/zsh/aliases.zsh
+++ b/home/dot_config/zsh/aliases.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # Zsh aliases
 #
 # Shell functions live in ~/.config/zsh/functions/ — one file per command.

--- a/home/dot_config/zsh/functions/brewup.zsh
+++ b/home/dot_config/zsh/functions/brewup.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # Update Homebrew + Brewfile, then any non-brew package managers (rustup)
 
 brewup() {
@@ -13,7 +13,7 @@ brewup() {
 
   local brewfile="$HOME/Brewfile"
   if [ -f "$brewfile" ]; then
-    echo "\n==> Installing packages from Brewfile..."
+    printf "\n==> Installing packages from Brewfile...\n"
     # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts;
     # brewup's whole point is unattended install/upgrade
     HOMEBREW_NO_ASK=1 brew bundle install --file "$brewfile"
@@ -21,7 +21,7 @@ brewup() {
     echo "Warning: Brewfile not found at $brewfile"
   fi
 
-  echo "\n==> Upgrading installed packages..."
+  printf "\n==> Upgrading installed packages...\n"
   HOMEBREW_NO_ASK=1 brew upgrade
 
   # Rust isn't in the Brewfile (rustup manages its own toolchain channel),
@@ -29,9 +29,9 @@ brewup() {
   # here, not in dotup.
   if command -v rustup >/dev/null 2>&1; then
     if [ "$BREWUP_SKIP_RUST" = "1" ]; then
-      echo "\n==> Skipping Rust toolchain update (BREWUP_SKIP_RUST=1)"
+      printf "\n==> Skipping Rust toolchain update (BREWUP_SKIP_RUST=1)\n"
     else
-      echo "\n==> Updating Rust toolchain..."
+      printf "\n==> Updating Rust toolchain...\n"
       # Pre-clean rustup's scratch dirs to avoid hours-long per-file cleanup
       # walks on EDR/AV-scanned machines. rustup recreates them as needed.
       rm -rf "$HOME/.rustup/tmp" "$HOME/.rustup/downloads"
@@ -39,5 +39,5 @@ brewup() {
     fi
   fi
 
-  echo "\n==> Packages up to date."
+  printf "\n==> Packages up to date.\n"
 }

--- a/home/dot_config/zsh/functions/claudeup.zsh
+++ b/home/dot_config/zsh/functions/claudeup.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # Configure Claude Code MCP servers (interactive, personal machines only)
 
 claudeup() {
@@ -20,7 +20,7 @@ claudeup() {
 
   # --- GitHub MCP (local binary + token from gh auth) ---
   if echo "$configured" | grep -q "github"; then
-    echo "\n==> GitHub MCP: already configured — skipping"
+    printf "\n==> GitHub MCP: already configured — skipping\n"
   else
     printf "\nConfigure GitHub MCP server? (y/n) "
     read -r answer
@@ -52,7 +52,7 @@ claudeup() {
 
   # --- Google Developer Knowledge API ---
   if echo "$configured" | grep -q "google-developer-knowledge"; then
-    echo "\n==> Google Developer Knowledge MCP: already configured — skipping"
+    printf "\n==> Google Developer Knowledge MCP: already configured — skipping\n"
   else
     printf "\nConfigure Google Developer Knowledge MCP server? (y/n) "
     read -r answer
@@ -72,7 +72,7 @@ claudeup() {
     fi
   fi
 
-  echo "\n==> MCP server setup complete."
+  printf "\n==> MCP server setup complete.\n"
   echo "Run 'claude mcp list' to verify."
 }
 

--- a/home/dot_config/zsh/functions/dotfuncs.zsh
+++ b/home/dot_config/zsh/functions/dotfuncs.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # List the custom shell functions installed by these dotfiles
 
 dotfuncs() {
@@ -13,7 +13,7 @@ dotfuncs() {
 
   echo "Update commands:"
   _dotfuncs_list "$dir" up
-  echo "\nOther commands:"
+  printf "\nOther commands:\n"
   _dotfuncs_list "$dir" other
 }
 

--- a/home/dot_config/zsh/functions/dotstatus.zsh
+++ b/home/dot_config/zsh/functions/dotstatus.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # Show dotfiles status: machine type, last applied, pending changes
 
 dotstatus() {

--- a/home/dot_config/zsh/functions/dotup.zsh
+++ b/home/dot_config/zsh/functions/dotup.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # Update dotfiles and plugins (does not install/upgrade packages)
 
 dotup() {
@@ -15,6 +15,7 @@ dotup() {
   # output, so it still surfaces and the recovery path keeps working.
   local update_log
   update_log=$(mktemp)
+  # shellcheck disable=SC2209  # PAGER=cat is an env prefix, not an assignment
   PAGER=cat chezmoi update --refresh-externals 2>&1 | tee "$update_log"
 
   # Auto-recover when chezmoi warns the rendered ~/.config/chezmoi/chezmoi.toml
@@ -23,15 +24,16 @@ dotup() {
   # key fail with "map has no entry for key X"). Re-init re-uses stored
   # promptChoiceOnce answers, so it's non-interactive.
   if grep -q "config file template has changed" "$update_log"; then
-    echo "\n==> Config template changed — regenerating with 'chezmoi init'..."
+    printf "\n==> Config template changed — regenerating with 'chezmoi init'...\n"
     chezmoi init
-    echo "\n==> Re-applying with refreshed config..."
+    printf "\n==> Re-applying with refreshed config...\n"
+    # shellcheck disable=SC2209  # PAGER=cat is an env prefix, not an assignment
     PAGER=cat chezmoi apply
   fi
   rm -f "$update_log"
 
   if [ -d "$ZSH" ]; then
-    echo "\n==> Updating Oh My Zsh..."
+    printf "\n==> Updating Oh My Zsh...\n"
     # -v silent: skip OMZ's ASCII-art banner and social-media plugs on success.
     # Errors still surface; our own ==> header announces the section.
     "$ZSH/tools/upgrade.sh" -v silent
@@ -40,23 +42,23 @@ dotup() {
   local plugin_dir="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins"
   for plugin in zsh-autosuggestions zsh-syntax-highlighting; do
     if [ -d "$plugin_dir/$plugin/.git" ]; then
-      echo "\n==> Updating $plugin..."
+      printf "\n==> Updating %s...\n" "$plugin"
       git -C "$plugin_dir/$plugin" pull
     fi
   done
 
   if [ -d "$HOME/.nano/.git" ]; then
-    echo "\n==> Updating nano syntax highlighting..."
+    printf "\n==> Updating nano syntax highlighting...\n"
     git -C "$HOME/.nano" pull
   fi
 
   if [ "$(uname -s)" = "Linux" ] && ! command -v brew >/dev/null 2>&1 \
      && command -v starship >/dev/null 2>&1; then
-    echo "\n==> Updating Starship..."
+    printf "\n==> Updating Starship...\n"
     curl -sS https://starship.rs/install.sh | sh -s -- -y
   fi
 
-  echo "\n==> Reloading shell aliases and functions..."
+  printf "\n==> Reloading shell aliases and functions...\n"
   # shellcheck source=/dev/null
   [ -f "$HOME/.config/zsh/aliases.zsh" ] && source "$HOME/.config/zsh/aliases.zsh"
   if [ -d "$HOME/.config/zsh/functions" ]; then
@@ -66,7 +68,7 @@ dotup() {
     done
   fi
 
-  echo "\n==> All updates complete."
+  printf "\n==> All updates complete.\n"
 
   # Remind the user what custom commands are available post-update.
   echo

--- a/home/dot_config/zsh/functions/note.zsh
+++ b/home/dot_config/zsh/functions/note.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # Quick project-scoped notes (also: notes, n alias)
 #
 # Notes are appended to ~/notes/<project>.md, where <project> is the git repo

--- a/home/dot_config/zsh/functions/xcodeup.zsh
+++ b/home/dot_config/zsh/functions/xcodeup.zsh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-# shellcheck disable=SC1071
+# shellcheck shell=bash
 # Install/update Xcode via xcodes, select the toolchain, download the iOS platform
 
 xcodeup() {
@@ -30,24 +30,24 @@ xcodeup() {
 
   # 'xcodes update' dumps the entire catalogue (every Xcode back to 1.0) to
   # stdout. Only the refresh matters here; stderr stays open for real errors.
-  echo "\n==> Refreshing available version list..."
+  printf "\n==> Refreshing available version list...\n"
   xcodes update >/dev/null
 
   # xcodes no-ops if the latest release is already installed. --select points
   # xcode-select at it either way, which is the part that silently stays on
   # CommandLineTools otherwise.
-  echo "\n==> Installing latest Xcode (prompts for Apple ID)..."
+  printf "\n==> Installing latest Xcode (prompts for Apple ID)...\n"
   if ! xcodes install --latest --select --experimental-unxip; then
     echo "Error: Xcode install failed."
     return 1
   fi
 
-  echo "\n==> Active toolchain: $(xcode-select -p)"
+  printf "\n==> Active toolchain: %s\n" "$(xcode-select -p)"
 
   # A fresh Xcode ships with no simulator runtimes; they are a separate
   # multi-GB download. xcodebuild no-ops when the platform is already
   # current, so this is safe to run on every invocation.
-  echo "\n==> Downloading iOS platform (simulator runtime)..."
+  printf "\n==> Downloading iOS platform (simulator runtime)...\n"
   if ! xcodebuild -downloadPlatform iOS; then
     echo "Warning: iOS platform download failed."
     echo "         Retry with: xcodebuild -downloadPlatform iOS"
@@ -55,7 +55,7 @@ xcodeup() {
 
   local runtimes
   runtimes="$(xcrun simctl list runtimes 2>/dev/null | grep -c '^iOS\|^watchOS\|^tvOS\|^visionOS')"
-  echo "\n==> ${runtimes} simulator runtime(s) installed."
+  printf "\n==> %s simulator runtime(s) installed.\n" "${runtimes}"
 
-  echo "\n==> Xcode up to date."
+  printf "\n==> Xcode up to date.\n"
 }


### PR DESCRIPTION
## Root cause — worse than the issue premise

While wiring `*.zsh` into CI I found the ShellCheck job has been a **complete silent no-op**, not just skipping zsh files:

1. **`scandir` takes a single directory.** The action passes it quoted to `find`, so `scandir: './scripts ./home'` ran `find "./scripts ./home"` → `No such file or directory` → zero files checked, exit 0, green tick. Confirmed in the job log of run 30568119396 on `main`.
2. **`# shellcheck disable=SC1071` makes shellcheck skip the file entirely** (no output, exit 0), rather than lint it. So even with discovery fixed, every `.zsh` file would still have been silently ignored. (The pinned action version already matches `*.zsh` in its `find` — no `additional_files` input needed.)

## Warning inventory (before → after)

Running shellcheck in bash mode over `home/dot_config/zsh/functions/*.zsh`: **25 findings → 0**.

| Code | Count | Files | Resolution |
| --- | --- | --- | --- |
| SC2028 (echo may not expand escapes) | 23 | brewup (5), claudeup (3), dotfuncs (1), dotup (8), xcodeup (6) | Converted `echo "\n==> ..."` to `printf "\n==> ...\n"`; used `%s` formats where variables/`$(...)` were interpolated |
| SC2209 (use var=$(command)) | 2 | dotup | Targeted per-line `disable=SC2209` — `PAGER=cat chezmoi ...` is a valid POSIX env prefix, false positive |

`dotstatus.zsh`, `note.zsh`, and `aliases.zsh` were already clean in bash mode. No file needed a genuine zsh-only construct preserved (no `${pipestatus[...]}` etc.), so nothing was scope-disabled at file level — all eight `.zsh` files now lint for real.

## Changes

- `.github/workflows/ci.yml` — `scandir: '.'` (single directory; the action's own `find` matches `*.sh`/`*.zsh`, excludes `.git`, and never matches `.tmpl` templates). Widens coverage to `install.sh` and the git-hook lib, which are also clean.
- All 8 `.zsh` files under `home/dot_config/zsh/` — `disable=SC1071` → `shell=bash` directive, so shellcheck lints them in bash mode instead of skipping.
- SC2028/SC2209 fixes as tabled above.

## Verification

- Reproduced the action's exact `find` + per-file `shellcheck --format=gcc` invocation locally against the repo root: 15 files discovered, **0 findings, exit 0** (shellcheck 0.11.0).
- `actionlint` on `ci.yml`: clean.
- `zsh -n` on all edited files: all parse.
- Smoke-tested `dotfuncs` description extraction (it skips `# shellcheck` lines) — output unchanged.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)