### PR TITLE
fix(brew): trust Brewfile-declared taps before brew bundle runs

### DIFF
--- a/home/dot_config/zsh/functions/brewup.zsh
+++ b/home/dot_config/zsh/functions/brewup.zsh
@@ -13,6 +13,14 @@ brewup() {
 
   local brewfile="$HOME/Brewfile"
   if [ -f "$brewfile" ]; then
+    # Homebrew 6 refuses non-official-tap formulae/casks unless trusted via
+    # 'brew trust'. Taps declared in the Brewfile are trusted by definition.
+    # Guarded for older brews without the 'trust' command.
+    if brew trust --help >/dev/null 2>&1; then
+      grep '^tap "' "$brewfile" | awk -F'"' '{print $2}' | while read -r tap_name; do
+        brew trust --tap "$tap_name" || true
+      done
+    fi
     printf "\n==> Installing packages from Brewfile...\n"
     # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts;
     # brewup's whole point is unattended install/upgrade

--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -16,6 +16,19 @@ case "$(uname -s)" in
     eval "$(/opt/homebrew/bin/brew shellenv)"
 
     BREWFILE="$HOME/Brewfile"
+
+    # Homebrew 6 refuses to load formulae/casks from non-official taps unless
+    # trusted via 'brew trust' (HOMEBREW_REQUIRE_TAP_TRUST defaults on).
+    # Declaring a tap in the Brewfile IS the trust decision, so trust each one
+    # here. This must run BEFORE the 'brew bundle check' guard below: an
+    # untrusted tap makes the check itself fail, which would fall through to
+    # the install path on every apply. Guarded for older brews without 'trust'.
+    if [ -f "$BREWFILE" ] && brew trust --help >/dev/null 2>&1; then
+      grep '^tap "' "$BREWFILE" | awk -F'"' '{print $2}' | while read -r tap_name; do
+        brew trust --tap "$tap_name" || true
+      done
+    fi
+
     if [ ! -f "$BREWFILE" ]; then
       echo "Warning: Brewfile not found at $BREWFILE, skipping brew bundle"
     elif brew bundle check --no-upgrade --file "$BREWFILE" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Fixes the main-branch macOS Test Install failure:

```text
Error: Refusing to load cask terraform-linters/tap/tflint from untrusted tap terraform-linters/tap.
```

Homebrew 6 enforces a tap-trust model by default (`HOMEBREW_REQUIRE_TAP_TRUST`): formulae/casks from non-official taps are refused unless trusted via `brew trust` (stored in `~/.homebrew/trust.json`). #361 added the tflint cask from `terraform-linters/tap`; PR CI passed because fast mode (`DOTFILES_SKIP_INSTALL=1`) never runs `brew bundle` — only the full install on push-to-main/schedule hit it, on a fresh runner with an empty trust store.

## Changes

- `home/run_once_after_install-brewfile.sh.tmpl`: parse `tap "..."` lines from the rendered Brewfile and `brew trust --tap` each, **before** the `brew bundle check` guard — an untrusted tap makes the check itself fail, which would otherwise fall through to the install path on every apply (violating ADR-0005's dotup-never-installs rule)
- `home/dot_config/zsh/functions/brewup.zsh`: same trust loop before its `brew bundle install`

Declaring a tap in the Brewfile is the trust decision, so trusting everything declared there is safe and covers future taps (personal machines also declare `aws/tap`, which has the same exposure). Both loops are guarded with `brew trust --help` for older brews without the command. The deprecated `HOMEBREW_NO_REQUIRE_TAP_TRUST` escape hatch is deliberately avoided.

## Verification

- Ran the parse-and-trust loop live against a real rendered Brewfile: `Trusted tap: aws/tap`, confirmed in `brew trust --json v1`
- `shellcheck` clean on `brewup.zsh`; template-stripped `sh -n` syntax check clean on the run_once script
- Note: PR CI runs fast mode and won't exercise the install — the real proof is the full macOS Test Install on the post-merge push

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)