### PR TITLE
fix(brew): force sequential brew bundle installs (HOMEBREW_BUNDLE_JOBS=1)

### DIFF
--- a/home/dot_config/zsh/functions/brewup.zsh
+++ b/home/dot_config/zsh/functions/brewup.zsh
@@ -23,8 +23,11 @@ brewup() {
     fi
     printf "\n==> Installing packages from Brewfile...\n"
     # HOMEBREW_NO_ASK=1: Homebrew 6 defaults to ask-mode confirmation prompts;
-    # brewup's whole point is unattended install/upgrade
-    HOMEBREW_NO_ASK=1 brew bundle install --file "$brewfile"
+    # brewup's whole point is unattended install/upgrade.
+    # HOMEBREW_BUNDLE_JOBS=1: Homebrew 6's parallel installer (default 'auto')
+    # has lock races on shared dependencies (Homebrew/brew#23328); sequential
+    # is the pre-brew-6 behavior. Revisit: dotfiles#368.
+    HOMEBREW_NO_ASK=1 HOMEBREW_BUNDLE_JOBS=1 brew bundle install --file "$brewfile"
   else
     echo "Warning: Brewfile not found at $brewfile"
   fi

--- a/home/run_once_after_install-brewfile.sh.tmpl
+++ b/home/run_once_after_install-brewfile.sh.tmpl
@@ -52,7 +52,11 @@ case "$(uname -s)" in
       # HOMEBREW_BUNDLE_NO_UPGRADE=1: install missing formulae only, leave
       # already-present-but-outdated packages alone — 'brewup' owns upgrades
       # (ADR-0005), so even the fresh-install path must not upgrade.
+      # HOMEBREW_BUNDLE_JOBS=1: Homebrew 6's parallel installer (default
+      # 'auto') has lock races on shared dependencies (Homebrew/brew#23328);
+      # sequential is the pre-brew-6 behavior. Revisit: dotfiles#368.
       HOMEBREW_BUNDLE_NO_LOCK=1 HOMEBREW_NO_ASK=1 HOMEBREW_BUNDLE_NO_UPGRADE=1 \
+        HOMEBREW_BUNDLE_JOBS=1 \
         brew bundle install --file "$BREWFILE"
     fi
     ;;


### PR DESCRIPTION
## Summary

Homebrew 6 runs `brew bundle install` with parallel workers by default (`HOMEBREW_BUNDLE_JOBS=auto`), and its scheduler has a known class of lock races on shared dependencies (Homebrew/brew#23328): workers die with "A `brew install --formula X` process has already locked …". This flaked the full macOS Test Install on main today — actionlint's `go` build dep collided with the top-level `go` install — and a plain re-run passed.

Upstream fixes (Homebrew/brew#23342, Homebrew/brew#23343) merged this week but are unreleased as of 6.0.13, and #23343's wait-instead-of-fail covers download locks only — Cellar/`FormulaLock` collisions like ours deliberately stay fail-fast. So this stays flaky for us even on the next brew release.

## Changes

Pin both `brew bundle install` call sites to sequential (`HOMEBREW_BUNDLE_JOBS=1` — the pre-brew-6 behavior and the maintainer-recommended workaround on #23328), with comments linking the upstream issue and the revisit ticket:

- `home/run_once_after_install-brewfile.sh.tmpl`
- `home/dot_config/zsh/functions/brewup.zsh`

Deliberately **no retry logic** — retries would mask genuine failures (bad formula, network outage) and add maintenance surface; one env var is smaller and self-documenting.

Re-enabling parallel installs is tracked in #368 with dated criteria (check from Nov 2026, decide by end of Jan 2027).

## Verification

- `shellcheck` clean on `brewup.zsh`; template-stripped `sh -n` clean on the run_once script
- Note: PR CI runs fast mode and doesn't execute `brew bundle`; the change only affects full installs on main/nightly and fresh machine provisions

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)