### PR TITLE
feat(brew): add tart to the personal Brewfile block

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -3,6 +3,7 @@
 
 {{- if eq .machine_type "personal" }}
 tap "aws/tap"
+tap "cirruslabs/cli"
 tap "terraform-linters/tap"
 
 brew "actionlint"
@@ -15,6 +16,7 @@ brew "beads"
 brew "bitwarden-cli"
 brew "chafa"
 brew "checkov"
+brew "cirruslabs/cli/tart"
 brew "cspell"
 brew "dolt"
 brew "dotnet"


### PR DESCRIPTION
Adds [`tart`](https://github.com/cirruslabs/tart) (Cirrus Labs' macOS VM tool) to the **personal** block only. Work and fallback tiers are unchanged.

```diff
 tap "aws/tap"
+tap "cirruslabs/cli"
 tap "terraform-linters/tap"

 brew "checkov"
+brew "cirruslabs/cli/tart"
 brew "cspell"
```

## It's a formula, not a cask

`tart.rb` sits at the root of `cirruslabs/homebrew-cli` (class `Tart`); the tap's `Casks/` directory contains only `chamber.rb`. So this is a `brew` line, not a `cask` line.

## Why the tap line is the whole trust fix

Homebrew 6 refuses non-official-tap formulae unless trusted, which surfaces as:

```
Error: Refusing to load formula cirruslabs/cli/softnet from untrusted tap cirruslabs/cli.
```

The error names `softnet` rather than `tart` because `tart.rb` declares `depends_on "cirruslabs/cli/softnet"`, so brew resolves the dependency first and trips on trust there. Both formulae live in the same tap, so a single tap-level trust covers both — matching the second suggestion in Homebrew's own error text (`brew trust cirruslabs/cli`).

No separate trust list is needed. The machinery from #366 already treats "declared in the Brewfile" as the trust decision: both `run_once_after_install-brewfile.sh.tmpl` and `brewup.zsh` parse `^tap "` out of the rendered Brewfile and run `brew trust --tap` *before* bundle install.

## Verification

Rendered `Brewfile.tmpl` for each `machine_type` and re-ran the trust extraction the scripts use:

| `machine_type` | taps trusted | tart present |
| --- | --- | --- |
| `personal` | `aws/tap`, `cirruslabs/cli`, `terraform-linters/tap` | yes |
| `work` | `terraform-linters/tap` | no |
| fallback | none | no |

## Notes

- tart declares `depends_on :macos => :ventura`.
- Filed under `c`, sorted by the full qualified string, consistent with how `cask "terraform-linters/tap/tflint"` sorts. Easy to switch to a short `brew "tart"` under `t` if you'd rather — the tap line makes either resolve.
- Pre-existing and not introduced here: on a genuinely fresh machine the tap isn't cloned locally when `brew trust --tap` runs, and I couldn't verify whether trust succeeds against an untapped tap. The existing two taps have identical exposure, and the `|| true` guard means it can't fail an apply either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEzFLESmAENUNGcgJbUEjQ)_