### PR TITLE
feat(claude): prune retired Claude config files after apply

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -42,6 +42,8 @@ Brewfile
 .tmux.conf
 run_onchange_setup-claude.sh
 setup-claude.sh
+run_after_prune-retired-claude-files.sh
+prune-retired-claude-files.sh
 run_once_after_setup-secrets.sh
 setup-secrets.sh
 {{- end }}

--- a/home/run_after_prune-retired-claude-files.sh
+++ b/home/run_after_prune-retired-claude-files.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Remove Claude config files that agentic-coding-config has retired.
+#
+# ~/.claude/ is mounted from agentic-coding-config via the archive external in
+# .chezmoiexternal.toml.tmpl. chezmoi only adds and updates target files — it
+# never removes a target whose source was deleted, so a retired slash command
+# survives on every machine that ever applied a version containing it, and
+# Claude Code goes on listing it.
+#
+# agentic-coding-config ships both halves of the fix: ~/.claude/retired-paths
+# (the list) and ~/.claude/bin/claude-prune-retired (the pruner). This script
+# is deliberately dumb — keeping the list upstream means retiring a file is a
+# one-repo change, and this script never needs to change again.
+# See agentic-coding-config#125.
+#
+# run_after_ (not run_onchange_): run_onchange_ re-runs when the script's own
+# contents change, but what actually changes is ~/.claude/retired-paths, which
+# arrives via the external and is invisible to this script's hash — it would
+# fire once and never again. The pruner is idempotent and cheap, so running it
+# on every apply is both correct and simpler.
+
+set -eu
+
+# The pruner arrives via the external, so on a first apply it may not exist
+# yet. Exit cleanly and let the next apply pick it up.
+[ -x "$HOME/.claude/bin/claude-prune-retired" ] || exit 0
+
+"$HOME/.claude/bin/claude-prune-retired"


### PR DESCRIPTION
Closes #371.

## Problem

`~/.claude/` is mounted from `agentic-coding-config` via an archive external. chezmoi only ever adds and updates target files — it never removes a target whose *source* was deleted. So a retired slash command survives on every machine that ever applied a version containing it, and Claude Code goes on listing it. Four `bd-*` files retired upstream in 2026-07 are still sitting on machines today.

## Approach

`agentic-coding-config` ships both halves of the actual fix — the `retired-paths` list and the `claude-prune-retired` pruner — so the list lives in the repo where retirements actually happen. This side just invokes it, which keeps retiring a file a one-repo change.

This supersedes the original `exact = true` idea in #371: that would delete anything not in the archive, including files added by hand on a machine. No change to `.chezmoiexternal.toml.tmpl` here.

## Two decisions worth flagging

**`run_after_`, not `run_onchange_`.** What actually changes is `~/.claude/retired-paths`, which arrives via the external and is invisible to this script's content hash — `run_onchange_` would fire once and never again. The pruner is idempotent and cheap, so running it every apply is both correct and simpler.

**Ignored on Windows**, matching every other `.sh` in this repo including `run_onchange_setup-claude.sh`.

## Verification

The upstream dependency, [`agentic-coding-config#132`](https://github.com/pmgledhill102/agentic-coding-config/pull/132), **merged at 18:59Z today**, so this is live rather than inert and the acceptance criteria are verifiable end-to-end. Tested by running *this script* against a sandboxed `HOME` with the **real** upstream `retired-paths` and `claude-prune-retired` (both confirmed present on `main`, pruner committed `100755`):

| #371 acceptance criterion | Result |
| --- | --- |
| Apply removes the four lingering `bd-*` files | pass — all four pruned |
| A future upstream entry is pruned with no change to this repo | pass — appended an entry, next apply removed it |
| `projects/`, `todos/`, `plugins/`, `history.jsonl`, `settings.local.json` untouched | pass — all intact, plus unretired commands |
| Apply on a machine that never had a retired file is a clean no-op | pass — silent, byte-identical tree, exit 0 |

Also confirmed: a second apply is a silent idempotent no-op, and unsafe entries (`/etc/passwd`, `../../escape.txt`) are refused while the apply still exits 0 — a bad entry can never fail an apply.

Beyond the end-to-end run: **ShellCheck clean** (new script and full repo scan), and `.chezmoiignore` renders correctly — ignored on `windows`, runs on `darwin` and `linux`.

The one criterion not mechanically verified is `/end-session` step 11 reporting no stale files, since that's an interactive workflow — but it follows from the four `bd-*` files being gone.

## Known gaps

- **Windows machines won't be pruned.** The `.claude` external isn't OS-gated, so retired files will linger there. Closing that needs a `.ps1` equivalent, which is beyond the scope here — worth its own issue.
- **No `|| true` on the pruner call**, per the design in #371, which relies on the pruner exiting 0 even on a bad entry. Verified above that it does. That contract lives in another repo, so a future upstream regression would fail `chezmoi apply` everywhere — flagging the coupling rather than quietly diverging.