### PR TITLE
feat(ci): run the lifeos Actions runner in a Tart VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
           # Scan the repo root: the action's own find picks up *.sh and *.zsh
           # and excludes .git; .tmpl files never match, so templates are skipped.
           scandir: '.'
+          # chezmoi's executable_ scripts have no extension, and the action's
+          # extensionless pass also requires the source file to carry the +x bit
+          # — which chezmoi sources don't. Without this they were silently never
+          # linted. Everything under this prefix is currently POSIX sh; an
+          # executable_*.ps1 would need excluding here.
+          additional_files: 'executable_*'
 
   markdown-lint:
     name: Markdown Lint

--- a/README.md
+++ b/README.md
@@ -149,6 +149,28 @@ podman info           # verify
 
 Linux uses the host kernel directly — no `podman machine` step needed.
 
+### Self-hosted CI runner VM (macOS only)
+
+The GitHub Actions runner for `lifeos` lives in a [Tart](https://tart.run) VM
+rather than on your own user account, so CI never runs as you with your
+keychain and session. `tart` comes from the Brewfile; the VM itself is a
+one-time build:
+
+```bash
+ci-vm-build     # ~66 GB image pull, then registers the runner. Idempotent.
+```
+
+Day to day it's two commands:
+
+```bash
+ci-vm-up        # before opening a PR or shipping — jobs queue while it's down
+ci-vm-down      # when done; refuses while a job is running
+```
+
+`ci-vm-destroy` deregisters the runner and deletes the VM. Full detail,
+configuration and troubleshooting in
+[docs/ci-runner-vm.md](docs/ci-runner-vm.md).
+
 ## Per-Platform Reference
 
 | | macOS | Linux / WSL | Windows |
@@ -257,6 +279,7 @@ Highly sensitive secrets (API keys, passwords) belong in Bitwarden, not here.
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — development workflow and code style
 - [docs/TESTING.md](docs/TESTING.md) — CI pipeline and validation scripts
+- [docs/ci-runner-vm.md](docs/ci-runner-vm.md) — self-hosted Actions runner in a Tart VM
 - [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) — common issues and fixes
 
 ## License

--- a/docs/ci-runner-vm.md
+++ b/docs/ci-runner-vm.md
@@ -7,7 +7,7 @@ account. Four scripts build, start, stop and destroy it:
 | Script | Does |
 | --- | --- |
 | `ci-vm-build` | Clone the Xcode image, size it, boot it, push an SSH key, install the build tooling, register the runner, install it as a launchd service. Idempotent. |
-| `ci-vm-up` | Start headless and detached, wait for an IP, poll GitHub until the runner reports online. Non-zero exit if it doesn't. |
+| `ci-vm-up` | Start headless and detached, wait for an IP, wait for the guest to boot and its runner agent to start, then poll GitHub until the runner reports online. Non-zero exit if any of that times out. |
 | `ci-vm-down` | Graceful `tart stop`. Refuses while the runner is mid-job unless `--force`. |
 | `ci-vm-destroy` | Deregister the runner from GitHub, then delete the VM. Prompts first. |
 
@@ -131,6 +131,24 @@ are easy to get wrong by hand:
   registration time. Over SSH that can omit `/opt/homebrew/bin`, and the
   workflows call `brew install xcodegen` — so `ci-vm-build` overwrites `.path`
   with `CI_VM_PATH` afterwards.
+
+## Why `ci-vm-up` doesn't just trust the API
+
+GitHub keeps reporting a runner as `online` for up to a minute after its VM
+stops. A `ci-vm-down; ci-vm-up` pair therefore reads that stale status and
+returns success while the guest is still booting — observed in practice, with
+`ci-vm-up` exiting successfully 0.4s after `tart run`.
+
+So `ci-vm-up` gates on evidence the API cannot provide, in order:
+
+1. `tart ip` returns an address,
+2. the guest answers on port 22 — it has actually booted,
+3. `launchctl` in the guest's GUI session shows a live pid for the runner
+   agent — it is alive in *this* boot,
+4. only then, the API reports `online`.
+
+A warm cycle takes about ten seconds end to end; the first boot after
+provisioning takes closer to 75.
 
 ## Labels
 

--- a/docs/ci-runner-vm.md
+++ b/docs/ci-runner-vm.md
@@ -1,0 +1,171 @@
+# Self-hosted CI runner in a Tart VM
+
+The GitHub Actions runner for [`lifeos`](https://github.com/pmgledhill102/lifeos)
+runs inside a [Tart](https://tart.run) macOS VM rather than on the host user
+account. Four scripts build, start, stop and destroy it:
+
+| Script | Does |
+| --- | --- |
+| `ci-vm-build` | Clone the Xcode image, size it, boot it, push an SSH key, install the build tooling, register the runner, install it as a launchd service. Idempotent. |
+| `ci-vm-up` | Start headless and detached, wait for an IP, poll GitHub until the runner reports online. Non-zero exit if it doesn't. |
+| `ci-vm-down` | Graceful `tart stop`. Refuses while the runner is mid-job unless `--force`. |
+| `ci-vm-destroy` | Deregister the runner from GitHub, then delete the VM. Prompts first. |
+
+They live in `home/dot_local/bin/` and land on `PATH` at `~/.local/bin/` after a
+`chezmoi apply`.
+
+## Why a VM
+
+The runner previously executed as `paul`, directly on the laptop, out of
+`~/dev/actions-runner-arm64`. Every workflow therefore ran as the daily-use user
+with that user's keychain and login session — LifeOS #968, #969 and #970 are all
+downstream of that single fact. Moving the runner into a VM fixes the class of
+problem rather than each instance.
+
+## Why one persistent VM, not ephemeral per-job VMs
+
+These are private repos, so run-to-run spillover isn't a threat worth paying
+for. Persistence keeps DerivedData warm between jobs, which is what makes
+incremental builds fast; an ephemeral VM would throw that away on every job.
+
+That decision is also why [Tartelet](https://github.com/shapehq/tartelet) isn't
+in the picture. Its whole purpose is spawning fresh VMs with just-in-time runner
+registration. Skip that and what remains is an ordinary runner installed inside
+a VM and registered as a launchd service: boot the VM, the service starts, the
+runner appears online; `tart stop`, it goes offline. No orchestration daemon,
+nothing to maintain. (Tartelet has also had no release in roughly twelve months
+and a growing issue backlog.)
+
+## Prerequisites
+
+- Apple silicon Mac. Tart uses Virtualization.framework.
+- `tart`, `gh`, `expect` — all installed by the Brewfile, `expect` ships with macOS.
+- `gh` authenticated with a token carrying `repo` scope; runner registration
+  tokens come from the API.
+- Roughly 150 GB free. The image is ~66 GB compressed and expands to a 140 GB
+  sparse disk.
+- Tart is fair-source: free for personal use, commercial use is gated. Check the
+  [current terms](https://tart.run/licensing/) before using it for work.
+
+## Everyday use
+
+```bash
+ci-vm-up        # before opening a PR or shipping
+ci-vm-down      # when done
+```
+
+`ci-vm-up` is the one to remember. With the VM down, jobs on
+`[self-hosted, macOS]` **queue rather than fail**, and GitHub gives up on them
+after about 24 hours. `ios-app-ci` and `macos-app-ci` are PR gates on those same
+labels, so a PR cannot go green with the VM off — "start the VM when I need a
+runner" means starting it to *open* a PR, not only to ship. Adding
+`timeout-minutes` to those jobs is worth doing alongside (LifeOS #942).
+
+Other useful states:
+
+```bash
+tart list                                  # is it running?
+tart ip ci-runner                          # address for ad-hoc SSH
+ssh -i ~/.ssh/ci-vm_ed25519 admin@$(tart ip ci-runner)
+gh api repos/pmgledhill102/lifeos/actions/runners --jq '.runners[].name'
+```
+
+## Configuration
+
+Every setting is a `CI_VM_*` variable with a default at the top of each script.
+Override per-machine in `~/.config/ci-vm.conf`, which all four scripts source if
+it exists, or via the environment for a one-off:
+
+```sh
+# ~/.config/ci-vm.conf
+CI_VM_CPU=8
+CI_VM_MEMORY=16384
+```
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `CI_VM_IMAGE` | `ghcr.io/cirruslabs/macos-sequoia-xcode:26.6` | Pins the Xcode version |
+| `CI_VM_XCODE` | `26.6` | Asserted against the booted VM; build fails on mismatch |
+| `CI_VM_NAME` | `ci-runner` | Tart VM name |
+| `CI_VM_CPU` | `6` | Of 10 on an M5 Air |
+| `CI_VM_MEMORY` | `12288` | MB |
+| `CI_VM_DISK` | `250` | GB, sparse |
+| `CI_VM_REPO` | `pmgledhill102/lifeos` | Repo the runner registers against |
+| `CI_VM_RUNNER_NAME` | `$CI_VM_NAME` | Name shown in GitHub's runner list |
+| `CI_VM_USER` / `CI_VM_PASSWORD` | `admin` / `admin` | Cirrus image defaults |
+| `CI_VM_KEY` | `~/.ssh/ci-vm_ed25519` | Generated on first build |
+| `CI_VM_PATH` | Homebrew + system paths | Baked into the runner's `.path` |
+| `CI_VM_BREW_PACKAGES` | `xcodegen fastlane` | Preinstalled into the guest |
+
+## Picking an image tag
+
+The tag pins Xcode, and a mismatch with what the workflows assume shows up as an
+opaque build failure — so `ci-vm-build` refuses to continue when the booted VM's
+`xcodebuild -version` doesn't equal `CI_VM_XCODE`.
+
+Cirrus publishes each Xcode release against two macOS bases. Both carry the same
+Xcode; only the host OS differs, and for `xcodebuild` the SDK comes from Xcode:
+
+```bash
+crane ls ghcr.io/cirruslabs/macos-sequoia-xcode
+crane ls ghcr.io/cirruslabs/macos-tahoe-xcode
+```
+
+`macos-runner:tahoe` bundles many Xcode versions at once and needs a 520 GB
+disk — too large for a laptop.
+
+## How the runner survives reboots
+
+`config.sh` registers the runner and `svc.sh install` writes a LaunchAgent with
+`RunAtLoad`, so the runner starts whenever `admin` logs in. The Cirrus images
+auto-login `admin`, so booting the VM is enough. Two details make this work that
+are easy to get wrong by hand:
+
+- **The agent must be loaded into the GUI session.** `svc.sh start` runs
+  `launchctl load` in whatever session invokes it; over SSH that's a background
+  session, and the agent dies with the connection. `ci-vm-build` instead uses
+  `sudo launchctl asuser "$(id -u)" launchctl load -w …`, which targets the
+  auto-logged-in Aqua session — the same domain the agent lands in on every
+  later boot.
+- **`.path` is pinned explicitly.** `config.sh` records whatever `PATH` it saw at
+  registration time. Over SSH that can omit `/opt/homebrew/bin`, and the
+  workflows call `brew install xcodegen` — so `ci-vm-build` overwrites `.path`
+  with `CI_VM_PATH` afterwards.
+
+## Labels
+
+GitHub adds `self-hosted`, `macOS` and `ARM64` automatically. That's exactly
+what `runs-on: [self-hosted, macOS]` already asks for, so the lifeos workflows
+needed no changes.
+
+## Signing and secrets
+
+Nothing sensitive is baked into the VM. `ios-testflight` and `mac-testflight`
+import the distribution certificate and profiles from repo secrets into a
+throwaway keychain at job time (LifeOS #973), so the VM needs no preinstalled
+signing material and destroying it loses nothing that isn't recoverable.
+
+## Troubleshooting
+
+**Runner won't come online after `ci-vm-up`.** The VM is up; the LaunchAgent is
+the suspect. Check its log inside the guest:
+
+```bash
+ssh -i ~/.ssh/ci-vm_ed25519 admin@$(tart ip ci-runner) \
+  'tail -50 ~/Library/Logs/actions.runner.*/stderr.log'
+```
+
+**`ci-vm-down` refuses to stop.** A job is running. Wait, or `--force` and
+accept that GitHub reports the job as lost rather than failed.
+
+**Builds fail with `brew: command not found`.** `.path` in the guest's
+`actions-runner/` has drifted. Re-run `ci-vm-build`; it rewrites the file every
+time.
+
+**Disk fills up.** The VM keeps DerivedData between jobs by design. Clear it in
+the guest, or raise `CI_VM_DISK` and re-run `ci-vm-build` — it grows the APFS
+container to match.
+
+**Starting over.** `ci-vm-destroy` then `ci-vm-build`. Deregistration goes
+through the API rather than `config.sh remove`, so it works even if the VM no
+longer boots.

--- a/home/dot_local/bin/executable_ci-vm-build
+++ b/home/dot_local/bin/executable_ci-vm-build
@@ -1,0 +1,308 @@
+#!/bin/sh
+# ci-vm-build — provision the self-hosted GitHub Actions runner VM.
+#
+# Clones a Cirrus Labs Xcode image with Tart, sizes it, boots it, pushes an SSH
+# key, installs the build tooling, then registers a GitHub Actions runner inside
+# the VM as a launchd LaunchAgent so it comes online whenever the VM boots.
+#
+# The VM is persistent by design: DerivedData stays warm between jobs, which is
+# what keeps incremental builds fast. Run-to-run isolation is deliberately
+# traded away — see docs/ci-runner-vm.md.
+#
+# Idempotent: re-running skips anything already done and reports what it
+# skipped, so a re-run doubles as a health check.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: ci-vm-build [--recreate] [--yes]
+
+  --recreate   destroy an existing VM (deregistering its runner) and start over
+  --yes, -y    skip the confirmation prompt that --recreate would otherwise ask
+
+Configuration is read from ~/.config/ci-vm.conf and the environment; see the
+CI_VM_* defaults at the top of this script.
+EOF
+}
+
+# --- Configuration ------------------------------------------------------
+# Override any of these in ~/.config/ci-vm.conf or via the environment.
+
+# shellcheck source=/dev/null
+[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf" ] &&
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf"
+
+# The image tag pins the Xcode version. A mismatch with what the workflows
+# expect surfaces as an opaque build failure, so CI_VM_XCODE is asserted against
+# the running VM below. List available tags with:
+#   crane ls ghcr.io/cirruslabs/macos-sequoia-xcode
+: "${CI_VM_IMAGE:=ghcr.io/cirruslabs/macos-sequoia-xcode:26.6}"
+: "${CI_VM_XCODE:=26.6}"
+: "${CI_VM_NAME:=ci-runner}"
+: "${CI_VM_CPU:=6}"
+: "${CI_VM_MEMORY:=12288}"
+: "${CI_VM_DISK:=250}"
+: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+: "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
+: "${CI_VM_RUNNER_DIR:=actions-runner}"
+: "${CI_VM_USER:=admin}"
+: "${CI_VM_PASSWORD:=admin}"
+: "${CI_VM_KEY:=$HOME/.ssh/ci-vm_ed25519}"
+# PATH baked into the runner's .path file. The LaunchAgent gets no login shell,
+# so Homebrew has to be on this list or `brew install xcodegen` fails mid-job.
+: "${CI_VM_PATH:=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin}"
+# Preinstalled formulae. The workflows install these themselves, but
+# preinstalling turns a two-minute step into a no-op.
+: "${CI_VM_BREW_PACKAGES:=xcodegen fastlane}"
+
+# --- Helpers ------------------------------------------------------------
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+skip() { printf '\033[1;33m --\033[0m %s\n' "$*"; }
+die() {
+  printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is not installed${2:+ — $2}"
+}
+
+# Empty when the VM does not exist, otherwise "running" / "stopped" / "suspended".
+vm_state() {
+  tart list --source local 2>/dev/null |
+    awk -v n="$CI_VM_NAME" '$2 == n { print $NF }'
+}
+
+# One field of the runner as GitHub sees it — the VM's own view of itself lags.
+runner_field() {
+  gh api "repos/$CI_VM_REPO/actions/runners" \
+    --jq ".runners[] | select(.name == \"$CI_VM_RUNNER_NAME\") | $1" \
+    2>/dev/null || true
+}
+
+ssh_vm() {
+  ssh -i "$CI_VM_KEY" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o LogLevel=ERROR \
+    -o BatchMode=yes \
+    -o ConnectTimeout=10 \
+    "$CI_VM_USER@$IP" "$@"
+}
+
+RECREATE=0
+ASSUME_YES=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --recreate) RECREATE=1 ;;
+    --yes | -y) ASSUME_YES=1 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+# --- Preflight ----------------------------------------------------------
+
+[ "$(uname -s)" = "Darwin" ] || die "Tart requires macOS on Apple silicon"
+
+need tart "brew install cirruslabs/cli/tart"
+need gh "brew install gh"
+need expect
+need ssh-copy-id
+
+gh auth status >/dev/null 2>&1 || die "gh is not authenticated — run: gh auth login"
+gh api "repos/$CI_VM_REPO" --jq .full_name >/dev/null 2>&1 ||
+  die "cannot read repos/$CI_VM_REPO — check the repo name and the gh token scopes"
+
+log "VM '$CI_VM_NAME' from $CI_VM_IMAGE"
+log "Runner '$CI_VM_RUNNER_NAME' on $CI_VM_REPO"
+
+# --- 1. Clone -----------------------------------------------------------
+
+if [ "$RECREATE" -eq 1 ] && [ -n "$(vm_state)" ]; then
+  if [ "$ASSUME_YES" -eq 0 ]; then
+    printf 'Destroy VM "%s" and deregister its runner? [y/N] ' "$CI_VM_NAME"
+    read -r reply
+    case "$reply" in
+      y | Y | yes | YES) ;;
+      *) die "aborted" ;;
+    esac
+  fi
+  log "Recreating — handing off to ci-vm-destroy"
+  ci-vm-destroy --yes
+fi
+
+if [ -n "$(vm_state)" ]; then
+  skip "VM '$CI_VM_NAME' already exists (use --recreate to start over)"
+else
+  log "Cloning $CI_VM_IMAGE — 66GB on a cold cache, so this takes a while"
+  tart clone "$CI_VM_IMAGE" "$CI_VM_NAME"
+  log "Sizing: ${CI_VM_CPU} CPU, ${CI_VM_MEMORY}MB RAM, ${CI_VM_DISK}GB disk"
+  tart set "$CI_VM_NAME" \
+    --cpu "$CI_VM_CPU" \
+    --memory "$CI_VM_MEMORY" \
+    --disk-size "$CI_VM_DISK"
+fi
+
+# --- 2. Boot ------------------------------------------------------------
+
+if [ "$(vm_state)" = "running" ]; then
+  skip "VM is already running"
+else
+  log "Booting headless"
+  # --no-runner: the runner does not exist yet on a first build.
+  ci-vm-up --no-runner
+fi
+
+IP="$(tart ip "$CI_VM_NAME" 2>/dev/null || true)"
+[ -n "$IP" ] || die "VM has no IP address yet — give it longer to boot, then re-run"
+log "VM is at $IP"
+
+# --- 3. SSH key ---------------------------------------------------------
+
+if [ ! -f "$CI_VM_KEY" ]; then
+  log "Generating SSH key $CI_VM_KEY"
+  ssh-keygen -t ed25519 -N '' -C "ci-vm@$(hostname -s)" -f "$CI_VM_KEY" >/dev/null
+fi
+
+if ssh_vm true 2>/dev/null; then
+  skip "SSH key already authorized"
+else
+  log "Pushing the SSH key (password auth, once)"
+  # ssh-copy-id has no non-interactive password mode, so expect drives it. The
+  # password reaches expect through the environment, never the script text.
+  CI_VM_PASSWORD="$CI_VM_PASSWORD" expect -c "
+    set timeout 120
+    spawn ssh-copy-id -i ${CI_VM_KEY}.pub \
+      -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null \
+      ${CI_VM_USER}@${IP}
+    expect {
+      -re {[Pp]assword:} { send \"\$env(CI_VM_PASSWORD)\r\"; exp_continue }
+      timeout { exit 1 }
+      eof
+    }
+    catch wait result
+    exit [lindex \$result 3]
+  " >/dev/null || die "could not push the SSH key to $CI_VM_USER@$IP"
+  ssh_vm true || die "key was copied but key-based auth still fails"
+fi
+
+# --- 4. Assert the Xcode version ---------------------------------------
+
+ACTUAL_XCODE="$(ssh_vm 'xcodebuild -version 2>/dev/null | head -1' | awk '{print $2}')"
+[ "$ACTUAL_XCODE" = "$CI_VM_XCODE" ] || die "VM has Xcode '$ACTUAL_XCODE', expected '$CI_VM_XCODE'.
+     Pin a matching CI_VM_IMAGE tag or update CI_VM_XCODE. Left alone, this
+     mismatch resurfaces later as an unexplained build failure."
+log "Xcode $ACTUAL_XCODE confirmed"
+
+# --- 5. Grow the APFS container ----------------------------------------
+
+# tart set --disk-size grows the disk image; macOS only sees the extra space
+# once the APFS container is resized. Harmless no-op when already at maximum.
+FREE_GB="$(ssh_vm "df -g / | awk 'NR==2 {print \$4}'")"
+if [ "${FREE_GB:-0}" -lt 100 ]; then
+  log "Growing the APFS container into the ${CI_VM_DISK}GB disk (${FREE_GB}GB free)"
+  # shellcheck disable=SC2016  # $store and $NF are expanded in the guest, not here
+  ssh_vm 'store=$(diskutil list | awk "/Apple_APFS/ {print \$NF; exit}") &&
+          sudo diskutil apfs resizeContainer "$store" 0' >/dev/null ||
+    skip "APFS resize failed — continuing, but watch for disk-full build errors"
+  FREE_GB="$(ssh_vm "df -g / | awk 'NR==2 {print \$4}'")"
+fi
+log "Free space in VM: ${FREE_GB}GB"
+
+# --- 6. Build tooling ---------------------------------------------------
+
+for pkg in $CI_VM_BREW_PACKAGES; do
+  if ssh_vm "PATH=$CI_VM_PATH command -v $pkg" >/dev/null 2>&1; then
+    skip "$pkg already installed"
+  else
+    log "Installing $pkg"
+    ssh_vm "PATH=$CI_VM_PATH HOMEBREW_NO_AUTO_UPDATE=1 brew install $pkg" >/dev/null ||
+      die "brew install $pkg failed"
+  fi
+done
+
+# --- 7. Register the runner --------------------------------------------
+
+if ssh_vm "[ -f '$CI_VM_RUNNER_DIR/.runner' ]"; then
+  skip "runner already configured in ~/$CI_VM_RUNNER_DIR"
+else
+  RUNNER_VERSION="$(gh api repos/actions/runner/releases/latest --jq .tag_name | sed 's/^v//')"
+  [ -n "$RUNNER_VERSION" ] || die "could not determine the latest runner version"
+  TARBALL="actions-runner-osx-arm64-${RUNNER_VERSION}.tar.gz"
+
+  log "Installing runner $RUNNER_VERSION"
+  ssh_vm "set -e
+    mkdir -p '$CI_VM_RUNNER_DIR' && cd '$CI_VM_RUNNER_DIR'
+    curl -fsSL -o '$TARBALL' \
+      'https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TARBALL}'
+    tar xzf '$TARBALL' && rm -f '$TARBALL'" ||
+    die "could not download and unpack the runner"
+
+  # Registration tokens expire after an hour, so fetch one as late as possible,
+  # and pass it over stdin so it never lands in the guest's process table.
+  log "Registering with $CI_VM_REPO"
+  REG_TOKEN="$(gh api -X POST \
+    "repos/$CI_VM_REPO/actions/runners/registration-token" --jq .token)"
+  [ -n "$REG_TOKEN" ] || die "could not obtain a runner registration token"
+  printf '%s\n' "$REG_TOKEN" | ssh_vm "set -e
+    cd '$CI_VM_RUNNER_DIR'
+    read -r token
+    ./config.sh --unattended --replace \
+      --url 'https://github.com/$CI_VM_REPO' \
+      --token \"\$token\" \
+      --name '$CI_VM_RUNNER_NAME' \
+      --work _work" ||
+    die "runner configuration failed"
+fi
+
+# config.sh records whatever PATH it saw. Over SSH that can miss Homebrew, and
+# the workflows call `brew install xcodegen` — so pin it explicitly.
+log "Pinning the service PATH"
+ssh_vm "printf '%s' '$CI_VM_PATH' > '$CI_VM_RUNNER_DIR/.path'"
+
+# --- 8. Install the LaunchAgent ----------------------------------------
+
+if ssh_vm "[ -f '$CI_VM_RUNNER_DIR/.service' ]"; then
+  skip "launchd service already installed"
+else
+  log "Installing the launchd service"
+  ssh_vm "cd '$CI_VM_RUNNER_DIR' && ./svc.sh install" >/dev/null ||
+    die "svc.sh install failed"
+fi
+
+# svc.sh start would load the agent into the SSH session's launchd domain, where
+# it dies with the connection. `launchctl asuser` targets the auto-logged-in GUI
+# session instead — the same domain it lands in on every subsequent boot.
+log "Loading the agent into the GUI session"
+ssh_vm "plist=\$(cat '$CI_VM_RUNNER_DIR/.service')
+  sudo launchctl asuser \"\$(id -u)\" launchctl load -w \"\$plist\" 2>/dev/null || true"
+
+# --- 9. Wait for the runner to report online ---------------------------
+
+log "Waiting for the runner to report online"
+status=""
+i=0
+while [ "$i" -lt 60 ]; do
+  status="$(runner_field .status)"
+  [ "$status" = "online" ] && break
+  i=$((i + 1))
+  sleep 5
+done
+[ "$status" = "online" ] || die "runner did not come online within five minutes.
+     Inspect the guest log:
+       ssh -i $CI_VM_KEY $CI_VM_USER@$IP 'tail -50 ~/Library/Logs/actions.runner.*/stderr.log'"
+
+log "Runner online with labels: $(runner_field '[.labels[].name] | join(",")')"
+log "Done. ci-vm-up and ci-vm-down take it from here."

--- a/home/dot_local/bin/executable_ci-vm-destroy
+++ b/home/dot_local/bin/executable_ci-vm-destroy
@@ -1,0 +1,131 @@
+#!/bin/sh
+# ci-vm-destroy — deregister the runner and delete the CI runner VM.
+#
+# Deregistration comes first and deliberately goes through the GitHub API rather
+# than `config.sh remove` inside the guest, so it works whether or not the VM
+# still boots. Deleting the VM without deregistering leaves a permanently
+# offline runner attached to the repo, which quietly swallows queued jobs.
+#
+# Everything the VM held is lost, warm DerivedData included: the next
+# ci-vm-build re-pulls the image and rebuilds from cold.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: ci-vm-destroy [--yes] [--keep-runner]
+
+  --yes, -y       skip the confirmation prompt
+  --keep-runner   delete the VM but leave the runner registered with GitHub
+                  (only useful when re-attaching the same runner name shortly)
+
+Configuration is read from ~/.config/ci-vm.conf and the environment; see the
+CI_VM_* defaults at the top of this script.
+EOF
+}
+
+# --- Configuration ------------------------------------------------------
+
+# shellcheck source=/dev/null
+[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf" ] &&
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf"
+
+: "${CI_VM_NAME:=ci-runner}"
+: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+: "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
+
+# --- Helpers ------------------------------------------------------------
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+skip() { printf '\033[1;33m --\033[0m %s\n' "$*"; }
+die() {
+  printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+vm_state() {
+  tart list --source local 2>/dev/null |
+    awk -v n="$CI_VM_NAME" '$2 == n { print $NF }'
+}
+
+runner_field() {
+  gh api "repos/$CI_VM_REPO/actions/runners" \
+    --jq ".runners[] | select(.name == \"$CI_VM_RUNNER_NAME\") | $1" \
+    2>/dev/null || true
+}
+
+ASSUME_YES=0
+KEEP_RUNNER=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yes | -y) ASSUME_YES=1 ;;
+    --keep-runner) KEEP_RUNNER=1 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+command -v tart >/dev/null 2>&1 || die "tart is not installed"
+
+state="$(vm_state)"
+runner_id="$(runner_field .id)"
+
+if [ -z "$state" ] && [ -z "$runner_id" ]; then
+  log "Nothing to do: no VM '$CI_VM_NAME' and no runner '$CI_VM_RUNNER_NAME'"
+  exit 0
+fi
+
+# --- Confirm ------------------------------------------------------------
+
+if [ "$ASSUME_YES" -eq 0 ]; then
+  printf 'About to destroy:\n'
+  [ -n "$state" ] && printf '  VM      %s (%s)\n' "$CI_VM_NAME" "$state"
+  [ -n "$runner_id" ] && [ "$KEEP_RUNNER" -eq 0 ] &&
+    printf '  runner  %s (id %s) on %s\n' "$CI_VM_RUNNER_NAME" "$runner_id" "$CI_VM_REPO"
+  printf 'This cannot be undone. Continue? [y/N] '
+  read -r reply
+  case "$reply" in
+    y | Y | yes | YES) ;;
+    *) die "aborted" ;;
+  esac
+fi
+
+# --- Deregister ---------------------------------------------------------
+
+if [ "$KEEP_RUNNER" -eq 1 ]; then
+  skip "leaving runner '$CI_VM_RUNNER_NAME' registered (--keep-runner)"
+elif [ -z "$runner_id" ]; then
+  skip "no runner named '$CI_VM_RUNNER_NAME' registered on $CI_VM_REPO"
+else
+  if [ "$(runner_field .busy)" = "true" ]; then
+    die "runner '$CI_VM_RUNNER_NAME' is mid-job — wait for it to finish, then retry"
+  fi
+  log "Deregistering runner $CI_VM_RUNNER_NAME (id $runner_id) from $CI_VM_REPO"
+  gh api -X DELETE "repos/$CI_VM_REPO/actions/runners/$runner_id" >/dev/null ||
+    die "could not deregister the runner — the VM has been left alone"
+fi
+
+# --- Delete the VM ------------------------------------------------------
+
+if [ -z "$state" ]; then
+  skip "no VM named '$CI_VM_NAME'"
+  exit 0
+fi
+
+if [ "$state" = "running" ]; then
+  log "Stopping '$CI_VM_NAME'"
+  tart stop "$CI_VM_NAME" --timeout 60 || die "could not stop the VM"
+fi
+
+log "Deleting VM '$CI_VM_NAME'"
+tart delete "$CI_VM_NAME"
+
+log "Done. ci-vm-build recreates it from scratch."

--- a/home/dot_local/bin/executable_ci-vm-down
+++ b/home/dot_local/bin/executable_ci-vm-down
@@ -1,0 +1,107 @@
+#!/bin/sh
+# ci-vm-down — stop the CI runner VM, gracefully.
+#
+# Refuses to stop while the runner is mid-job: `tart stop` would kill the VM out
+# from under a running build, which GitHub reports as a lost job rather than a
+# clear failure. Pass --force to stop anyway.
+#
+# With the VM down, jobs on [self-hosted, macOS] queue rather than fail, and
+# GitHub gives up on them after about 24 hours.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: ci-vm-down [--force] [--timeout SECONDS]
+
+  --force            stop even if the runner is mid-job
+  --timeout SECONDS  seconds to allow for graceful shutdown before Tart pulls
+                     the plug (default 60)
+
+Configuration is read from ~/.config/ci-vm.conf and the environment; see the
+CI_VM_* defaults at the top of this script.
+EOF
+}
+
+# --- Configuration ------------------------------------------------------
+
+# shellcheck source=/dev/null
+[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf" ] &&
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf"
+
+: "${CI_VM_NAME:=ci-runner}"
+: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+: "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
+
+# --- Helpers ------------------------------------------------------------
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() {
+  printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+vm_state() {
+  tart list --source local 2>/dev/null |
+    awk -v n="$CI_VM_NAME" '$2 == n { print $NF }'
+}
+
+runner_field() {
+  gh api "repos/$CI_VM_REPO/actions/runners" \
+    --jq ".runners[] | select(.name == \"$CI_VM_RUNNER_NAME\") | $1" \
+    2>/dev/null || true
+}
+
+FORCE=0
+TIMEOUT=60
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force | -f) FORCE=1 ;;
+    --timeout)
+      shift
+      TIMEOUT="${1:-}"
+      [ -n "$TIMEOUT" ] || die "--timeout needs a value"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+command -v tart >/dev/null 2>&1 || die "tart is not installed"
+
+state="$(vm_state)"
+[ -n "$state" ] || die "VM '$CI_VM_NAME' does not exist"
+if [ "$state" != "running" ]; then
+  log "VM '$CI_VM_NAME' is already $state — nothing to do"
+  exit 0
+fi
+
+# --- Busy check ---------------------------------------------------------
+
+if [ "$FORCE" -eq 1 ]; then
+  log "--force given — not checking whether the runner is busy"
+elif ! command -v gh >/dev/null 2>&1; then
+  die "gh is not installed, so the busy check cannot run — pass --force to stop anyway"
+else
+  busy="$(runner_field .busy)"
+  if [ "$busy" = "true" ]; then
+    die "runner '$CI_VM_RUNNER_NAME' is mid-job.
+     Wait for it to finish, or pass --force to stop anyway (the job will be lost)."
+  fi
+  log "Runner is idle (status: $(runner_field .status))"
+fi
+
+# --- Stop ---------------------------------------------------------------
+
+log "Stopping '$CI_VM_NAME' (up to ${TIMEOUT}s for a graceful shutdown)"
+tart stop "$CI_VM_NAME" --timeout "$TIMEOUT"
+
+log "VM '$CI_VM_NAME' is $(vm_state). Queued jobs will wait for the next ci-vm-up."

--- a/home/dot_local/bin/executable_ci-vm-up
+++ b/home/dot_local/bin/executable_ci-vm-up
@@ -33,6 +33,8 @@ EOF
 : "${CI_VM_REPO:=pmgledhill102/lifeos}"
 : "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
 : "${CI_VM_LOG_DIR:=${XDG_STATE_HOME:-$HOME/.local/state}/ci-vm}"
+: "${CI_VM_USER:=admin}"
+: "${CI_VM_KEY:=$HOME/.ssh/ci-vm_ed25519}"
 
 # --- Helpers ------------------------------------------------------------
 
@@ -81,6 +83,7 @@ command -v tart >/dev/null 2>&1 || die "tart is not installed"
 
 # --- Boot ---------------------------------------------------------------
 
+BOOTED=0
 if [ "$(vm_state)" = "running" ]; then
   log "VM '$CI_VM_NAME' is already running"
 else
@@ -90,6 +93,7 @@ else
   # Detached: `tart run` stays in the foreground for the VM's lifetime, so it
   # has to outlive this shell.
   nohup tart run --no-graphics "$CI_VM_NAME" >>"$VM_LOG" 2>&1 &
+  BOOTED=1
 fi
 
 log "Waiting for an IP address"
@@ -105,11 +109,49 @@ done
      Check $CI_VM_LOG_DIR/$CI_VM_NAME.log"
 log "VM is at $IP"
 
+# GitHub keeps reporting a runner online for up to a minute after its VM stops,
+# so a `ci-vm-down; ci-vm-up` pair would otherwise read that stale "online" and
+# return success while the guest was still booting. Waiting for sshd proves the
+# guest is actually up before any status is believed.
+if [ "$BOOTED" -eq 1 ]; then
+  log "Waiting for the guest to finish booting"
+  i=0
+  while [ "$i" -lt 90 ]; do
+    nc -z -G 2 "$IP" 22 >/dev/null 2>&1 && break
+    i=$((i + 1))
+    sleep 2
+  done
+  [ "$i" -lt 90 ] || die "guest did not answer on port 22 within three minutes.
+     Check $CI_VM_LOG_DIR/$CI_VM_NAME.log"
+fi
+
 [ "$WAIT_RUNNER" -eq 1 ] || exit 0
 
 # --- Wait for the runner ------------------------------------------------
 
 command -v gh >/dev/null 2>&1 || die "gh is not installed — cannot check runner status"
+
+# Belt and braces on the stale-status problem above: the LaunchAgent holding a
+# pid in the guest is proof the runner is alive in *this* boot, which no reading
+# of the API can give us. Skipped when the key is missing, since the API poll
+# below is still a useful check on its own.
+if [ -f "$CI_VM_KEY" ]; then
+  log "Waiting for the runner agent to start in the guest"
+  i=0
+  while [ "$i" -lt 60 ]; do
+    ssh -i "$CI_VM_KEY" \
+      -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+      -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=10 \
+      "$CI_VM_USER@$IP" \
+      'sudo launchctl asuser "$(id -u)" launchctl list |
+         awk "/actions\.runner/ && \$1 != \"-\" { found = 1 } END { exit !found }"' \
+      >/dev/null 2>&1 && break
+    i=$((i + 1))
+    sleep 5
+  done
+  [ "$i" -lt 60 ] || die "the runner agent never started inside the guest.
+     Inspect it: ssh -i $CI_VM_KEY $CI_VM_USER@$IP 'tail -50 ~/Library/Logs/actions.runner.*/stderr.log'"
+fi
 
 log "Waiting for runner '$CI_VM_RUNNER_NAME' to report online"
 status=""

--- a/home/dot_local/bin/executable_ci-vm-up
+++ b/home/dot_local/bin/executable_ci-vm-up
@@ -1,0 +1,127 @@
+#!/bin/sh
+# ci-vm-up — start the CI runner VM and wait for its runner to report online.
+#
+# Boots the VM headless and detached, waits for it to take an IP, then polls the
+# GitHub API until the runner shows online. Exits non-zero if either step times
+# out, so it is safe to chain: `ci-vm-up && gh pr create ...`.
+#
+# The runner is a LaunchAgent inside the VM, so nothing has to be started by
+# hand — booting the VM is the whole story.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: ci-vm-up [--no-runner] [--timeout SECONDS]
+
+  --no-runner        return once the VM has an IP, without waiting for the
+                     runner (used by ci-vm-build, before one is registered)
+  --timeout SECONDS  how long to wait for the runner to come online (default 300)
+
+Configuration is read from ~/.config/ci-vm.conf and the environment; see the
+CI_VM_* defaults at the top of this script.
+EOF
+}
+
+# --- Configuration ------------------------------------------------------
+
+# shellcheck source=/dev/null
+[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf" ] &&
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf"
+
+: "${CI_VM_NAME:=ci-runner}"
+: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+: "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
+: "${CI_VM_LOG_DIR:=${XDG_STATE_HOME:-$HOME/.local/state}/ci-vm}"
+
+# --- Helpers ------------------------------------------------------------
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() {
+  printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+vm_state() {
+  tart list --source local 2>/dev/null |
+    awk -v n="$CI_VM_NAME" '$2 == n { print $NF }'
+}
+
+runner_field() {
+  gh api "repos/$CI_VM_REPO/actions/runners" \
+    --jq ".runners[] | select(.name == \"$CI_VM_RUNNER_NAME\") | $1" \
+    2>/dev/null || true
+}
+
+WAIT_RUNNER=1
+TIMEOUT=300
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-runner) WAIT_RUNNER=0 ;;
+    --timeout)
+      shift
+      TIMEOUT="${1:-}"
+      [ -n "$TIMEOUT" ] || die "--timeout needs a value"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "unknown option: $1"
+    ;;
+  esac
+  shift
+done
+
+command -v tart >/dev/null 2>&1 || die "tart is not installed"
+[ -n "$(vm_state)" ] || die "VM '$CI_VM_NAME' does not exist — run ci-vm-build first"
+
+# --- Boot ---------------------------------------------------------------
+
+if [ "$(vm_state)" = "running" ]; then
+  log "VM '$CI_VM_NAME' is already running"
+else
+  mkdir -p "$CI_VM_LOG_DIR"
+  VM_LOG="$CI_VM_LOG_DIR/$CI_VM_NAME.log"
+  log "Booting '$CI_VM_NAME' headless (log: $VM_LOG)"
+  # Detached: `tart run` stays in the foreground for the VM's lifetime, so it
+  # has to outlive this shell.
+  nohup tart run --no-graphics "$CI_VM_NAME" >>"$VM_LOG" 2>&1 &
+fi
+
+log "Waiting for an IP address"
+IP=""
+i=0
+while [ "$i" -lt 60 ]; do
+  IP="$(tart ip "$CI_VM_NAME" 2>/dev/null || true)"
+  [ -n "$IP" ] && break
+  i=$((i + 1))
+  sleep 2
+done
+[ -n "$IP" ] || die "VM did not take an IP address within two minutes.
+     Check $CI_VM_LOG_DIR/$CI_VM_NAME.log"
+log "VM is at $IP"
+
+[ "$WAIT_RUNNER" -eq 1 ] || exit 0
+
+# --- Wait for the runner ------------------------------------------------
+
+command -v gh >/dev/null 2>&1 || die "gh is not installed — cannot check runner status"
+
+log "Waiting for runner '$CI_VM_RUNNER_NAME' to report online"
+status=""
+elapsed=0
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  status="$(runner_field .status)"
+  [ "$status" = "online" ] && break
+  elapsed=$((elapsed + 5))
+  sleep 5
+done
+
+[ "$status" = "online" ] || die "runner did not come online within ${TIMEOUT}s (last status: ${status:-not registered}).
+     The VM is up; the LaunchAgent inside it is the thing to look at."
+
+log "Runner '$CI_VM_RUNNER_NAME' is online — jobs on [self-hosted, macOS] will pick up"


### PR DESCRIPTION
Closes #376.

A self-hosted GitHub Actions runner for macOS builds now runs inside a Tart VM rather than on the host user account. It previously executed as `paul`, directly on the laptop, so every workflow ran as the daily-use user with that user's keychain and login session in reach. Moving it into a VM fixes that class of problem once, rather than case by case.

**The cutover is done, not just proposed.** The VM runner is live, the host runner is deregistered and its directory removed.

> **Edited:** this description originally named a private repo, its internal issue numbers and its signing arrangement. Removed — see #380/#381. Nothing secret was exposed; registration tokens are fetched at runtime.

## What's here

Four scripts in `home/dot_local/bin/` (land on `PATH` at `~/.local/bin/`):

| Script | Does |
| --- | --- |
| `ci-vm-build` | Clone the Xcode image, size it, boot it, push an SSH key, install tooling, register the runner, install it as a launchd service. Idempotent. |
| `ci-vm-up` | Start headless and detached, then wait for an IP, for the guest to boot, for its runner agent to start, and for GitHub to report online. Non-zero exit if any of that times out. |
| `ci-vm-down` | Graceful `tart stop`. Refuses while the runner is mid-job unless `--force`. |
| `ci-vm-destroy` | Deregister from GitHub, then delete the VM. Prompts first. |

Plus `docs/ci-runner-vm.md` and a README section. `tart` was already in the Brewfile, so no package change.

## Three details worth reviewing

All three are things that look fine and then fail hours later:

- **The LaunchAgent is loaded with `launchctl asuser`, not `svc.sh start`.** `svc.sh start` runs `launchctl load` in whatever session invokes it; over SSH that's a background session and the agent dies with the connection. `asuser` targets the auto-logged-in Aqua session — the same domain it lands in on every subsequent boot.
- **`.path` is pinned after `config.sh`.** `config.sh` records whatever `PATH` it saw at registration. Over SSH that omits `/opt/homebrew/bin`, and jobs call `brew install`.
- **`ci-vm-up` does not trust the API alone** (second commit). See below.

## The bug the testing found

The first `ci-vm-down; ci-vm-up` cycle had `ci-vm-up` exit *successfully* 0.4s after `tart run`. GitHub keeps reporting a runner `online` for up to a minute after its VM stops, so the poll read a stale status and claimed a runner that wasn't there.

`ci-vm-up` now gates on evidence the API can't provide: port 22 answering (the guest really booted), then `launchctl` in the guest's GUI session showing a live pid for the runner agent (it's alive in *this* boot), and only then the API status.

## Image choice

`ghcr.io/cirruslabs/macos-sequoia-xcode:26.6` — Xcode 26.6, matching the host. The `macos-tahoe-xcode` repo tops out at 26.5; `macos-runner:tahoe` bundles many Xcodes and wants a 520 GB disk. `ci-vm-build` asserts the guest's `xcodebuild -version` against `CI_VM_XCODE` and refuses to continue on a mismatch, since that failure is otherwise opaque.

## Verified end to end

- `ci-vm-build` ran clean on a cold cache: clone → boot → key push → Xcode assert → tooling → registration → agent → online with `self-hosted,macOS,ARM64`.
- Re-ran it: every step reported skipped, nothing re-done.
- The busy guard in `ci-vm-down` fired unprompted — the new runner had already claimed queued jobs, and `ci-vm-down` refused to kill them.
- Real queued release and PR-gate workflows completed successfully from inside the VM, confirmed via the jobs API as running on the VM's runner.
- **The runner returns unaided after a cold boot** — the risk the issue flagged. Verified by comparing the guest's `kern.boottime` across a stop/start: the boot epoch changes and the runner comes back with no manual `launchctl`. First boot after provisioning ~75s; a warm cycle ~10s.
- Old host runner deregistered and its directory removed (1.4 GB; nothing in it but CI checkouts and build artefacts).

## Also in here

The ShellCheck job was silently skipping every `executable_` script — they have no extension, and the action's extensionless pass also requires a `+x` bit that chezmoi sources don't carry. `additional_files: 'executable_*'` fixes it. Replicating the action's own `find` locally confirms the linted set goes from zero of these files to all five. This also newly lints the pre-existing `executable_gh-statusline-counts` (already clean).

## Trade-off, stated deliberately

With the VM down, jobs on `[self-hosted, macOS]` queue rather than fail and GitHub gives up after ~24h. If such a job is a required PR check, a PR can't go green with the VM off — `ci-vm-up` is needed to *open* a PR, not just to ship. Giving those jobs a `timeout-minutes` is worth doing alongside.

## Note for after merge

The scripts reach `PATH` via `chezmoi update` in `~/.local/share/chezmoi` (a separate clone from this working repo), so run that once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)