### PR TITLE
fix(zsh): list ~/.local/bin scripts in dotfuncs

### DIFF
--- a/home/dot_config/zsh/functions/dotfuncs.zsh
+++ b/home/dot_config/zsh/functions/dotfuncs.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # shellcheck shell=bash
-# List the custom shell functions installed by these dotfiles
+# List the custom shell functions and scripts installed by these dotfiles
 
 dotfuncs() {
   local dir
@@ -15,6 +15,7 @@ dotfuncs() {
   _dotfuncs_list "$dir" up
   printf "\nOther commands:\n"
   _dotfuncs_list "$dir" other
+  _dotfuncs_scripts "$HOME/.local/bin"
 }
 
 # Helper: print one group of functions. Mode 'up' selects the *up commands
@@ -43,5 +44,45 @@ _dotfuncs_list() {
       }
     ' "$file")
     printf "  %-11s %s\n" "$name" "$desc"
+  done
+}
+
+# Helper: print the standalone scripts these dotfiles install onto PATH. They
+# aren't shell functions, so the loop above never sees them — but from the
+# prompt they're the same thing: a command you can type.
+_dotfuncs_scripts() {
+  local dir="$1" file name desc found=0
+
+  [ -d "$dir" ] || return 0
+
+  for file in "$dir"/*; do
+    # ~/.local/bin also holds the chezmoi binary and personal symlinks into
+    # project checkouts. Requiring a regular file with a shebang keeps the list
+    # to scripts this repo actually installs.
+    [ -f "$file" ] && [ ! -L "$file" ] || continue
+    head -n 1 "$file" | grep -q '^#!' || continue
+
+    name="${file##*/}"
+
+    # Same first-comment-line convention as the functions above, except these
+    # open with "name — description", so the name is stripped to avoid
+    # printing it twice.
+    desc=$(awk -v n="$name" '
+      /^#!/           { next }
+      /^# shellcheck/ { next }
+      /^#[[:space:]]/ {
+        sub(/^#[[:space:]]*/, "")
+        sub("^" n "[[:space:]]*[-—][[:space:]]*", "")
+        # Match the sentence style of the function descriptions above.
+        sub(/\.$/, "")
+        print toupper(substr($0, 1, 1)) substr($0, 2)
+        exit
+      }
+    ' "$file")
+    [ -n "$desc" ] || continue
+
+    [ "$found" -eq 1 ] || printf "\nScripts:\n"
+    found=1
+    printf "  %-21s %s\n" "$name" "$desc"
   done
 }


### PR DESCRIPTION
Closes #378.

`dotfuncs` enumerated `~/.config/zsh/functions/*.zsh` only, so the `ci-vm-*` commands from #377 got installed onto `PATH` and were then invisible to the helper whose entire job is discoverability. `gh-statusline-counts` had the same problem before them.

## After

```text
Other commands:
  dotbrew     Deprecated alias — 'dotbrew' was renamed to 'brewup'. Remove after one release cycle
  dotclaude   Configure Claude Code MCP servers (interactive, personal machines only)
  dotfuncs    List the custom shell functions and scripts installed by these dotfiles
  dotstatus   Show dotfiles status: machine type, last applied, pending changes
  note        Quick project-scoped notes (also: notes, n alias)

Scripts:
  ci-vm-build           Provision the self-hosted GitHub Actions runner VM
  ci-vm-destroy         Deregister the runner and delete the CI runner VM
  ci-vm-down            Stop the CI runner VM, gracefully
  ci-vm-up              Start the CI runner VM and wait for its runner to report online
  gh-statusline-counts  Open GitHub issue/PR counts for the current repo
```

## Three details

- **Only lists what these dotfiles installed.** `~/.local/bin` also holds the `chezmoi` binary and personal symlinks into project checkouts (`cloudcoop` → `~/dev/cloud-coop/bin/`). Requiring a regular file with a shebang excludes both — verified, neither appears.
- **Strips the `name — ` prefix.** Standalone scripts open with `# ci-vm-up — start the CI runner VM…`, unlike the zsh functions whose first comment is the bare description, so the name would otherwise print twice.
- **Normalises sentence style** (capitalise, drop the trailing full stop) so the two sections read as one list, and widens the name column — `gh-statusline-counts` is 20 chars against the old `%-11s`.

ShellCheck clean; output above is a real run.
