### PR TITLE
docs(ci): remove private-repo detail from the public runner VM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,11 @@ Linux uses the host kernel directly — no `podman machine` step needed.
 
 ### Self-hosted CI runner VM (macOS only)
 
-The GitHub Actions runner for `lifeos` lives in a [Tart](https://tart.run) VM
-rather than on your own user account, so CI never runs as you with your
-keychain and session. `tart` comes from the Brewfile; the VM itself is a
-one-time build:
+Self-hosted GitHub Actions runners for macOS builds live in a
+[Tart](https://tart.run) VM rather than on your own user account, so CI never
+runs as you with your keychain and session. `tart` comes from the Brewfile. Set
+`CI_VM_REPO` in `~/.config/ci-vm.conf` (untracked — this repo is public), then
+build the VM once:
 
 ```bash
 ci-vm-build     # ~66 GB image pull, then registers the runner. Idempotent.

--- a/docs/ci-runner-vm.md
+++ b/docs/ci-runner-vm.md
@@ -1,8 +1,9 @@
 # Self-hosted CI runner in a Tart VM
 
-The GitHub Actions runner for [`lifeos`](https://github.com/pmgledhill102/lifeos)
-runs inside a [Tart](https://tart.run) macOS VM rather than on the host user
-account. Four scripts build, start, stop and destroy it:
+A self-hosted GitHub Actions runner for macOS builds, running inside a
+[Tart](https://tart.run) VM rather than on the host user account. Four scripts
+build, start, stop and destroy it. Which repo it registers against is machine
+configuration, not something this repo records — see [Configuration](#configuration).
 
 | Script | Does |
 | --- | --- |
@@ -16,11 +17,10 @@ They live in `home/dot_local/bin/` and land on `PATH` at `~/.local/bin/` after a
 
 ## Why a VM
 
-The runner previously executed as `paul`, directly on the laptop, out of
-`~/dev/actions-runner-arm64`. Every workflow therefore ran as the daily-use user
-with that user's keychain and login session — LifeOS #968, #969 and #970 are all
-downstream of that single fact. Moving the runner into a VM fixes the class of
-problem rather than each instance.
+The runner previously executed as `paul`, directly on the laptop. Every workflow
+therefore ran as the daily-use user, with that user's keychain and login session
+in reach. Moving the runner into a VM fixes that class of problem once, rather
+than case by case.
 
 ## Why one persistent VM, not ephemeral per-job VMs
 
@@ -56,10 +56,10 @@ ci-vm-down      # when done
 
 `ci-vm-up` is the one to remember. With the VM down, jobs on
 `[self-hosted, macOS]` **queue rather than fail**, and GitHub gives up on them
-after about 24 hours. `ios-app-ci` and `macos-app-ci` are PR gates on those same
-labels, so a PR cannot go green with the VM off — "start the VM when I need a
-runner" means starting it to *open* a PR, not only to ship. Adding
-`timeout-minutes` to those jobs is worth doing alongside (LifeOS #942).
+after about 24 hours. If any such job is a required PR check, a PR cannot go
+green with the VM off — "start the VM when I need a runner" means starting it to
+*open* a PR, not only to ship. Giving those jobs a `timeout-minutes` is worth
+doing alongside, so a forgotten VM fails fast instead of hanging for a day.
 
 Other useful states:
 
@@ -67,17 +67,23 @@ Other useful states:
 tart list                                  # is it running?
 tart ip ci-runner                          # address for ad-hoc SSH
 ssh -i ~/.ssh/ci-vm_ed25519 admin@$(tart ip ci-runner)
-gh api repos/pmgledhill102/lifeos/actions/runners --jq '.runners[].name'
+gh api "repos/$CI_VM_REPO/actions/runners" --jq '.runners[].name'
 ```
 
 ## Configuration
 
 Every setting is a `CI_VM_*` variable with a default at the top of each script.
 Override per-machine in `~/.config/ci-vm.conf`, which all four scripts source if
-it exists, or via the environment for a one-off:
+it exists, or via the environment for a one-off.
+
+`CI_VM_REPO` has no default and must be set — this repo is public, so which
+repo the runner attaches to is deliberately machine configuration rather than
+something recorded here. `~/.config/ci-vm.conf` is not chezmoi-managed, so it
+stays local:
 
 ```sh
 # ~/.config/ci-vm.conf
+CI_VM_REPO=owner/repo
 CI_VM_CPU=8
 CI_VM_MEMORY=16384
 ```
@@ -90,7 +96,7 @@ CI_VM_MEMORY=16384
 | `CI_VM_CPU` | `6` | Of 10 on an M5 Air |
 | `CI_VM_MEMORY` | `12288` | MB |
 | `CI_VM_DISK` | `250` | GB, sparse |
-| `CI_VM_REPO` | `pmgledhill102/lifeos` | Repo the runner registers against |
+| `CI_VM_REPO` | *(none — required)* | Repo the runner registers against |
 | `CI_VM_RUNNER_NAME` | `$CI_VM_NAME` | Name shown in GitHub's runner list |
 | `CI_VM_USER` / `CI_VM_PASSWORD` | `admin` / `admin` | Cirrus image defaults |
 | `CI_VM_KEY` | `~/.ssh/ci-vm_ed25519` | Generated on first build |
@@ -152,16 +158,16 @@ provisioning takes closer to 75.
 
 ## Labels
 
-GitHub adds `self-hosted`, `macOS` and `ARM64` automatically. That's exactly
-what `runs-on: [self-hosted, macOS]` already asks for, so the lifeos workflows
-needed no changes.
+GitHub adds `self-hosted`, `macOS` and `ARM64` automatically, which is what a
+`runs-on: [self-hosted, macOS]` job already asks for — so workflows written
+against the old host runner need no changes.
 
 ## Signing and secrets
 
-Nothing sensitive is baked into the VM. `ios-testflight` and `mac-testflight`
-import the distribution certificate and profiles from repo secrets into a
-throwaway keychain at job time (LifeOS #973), so the VM needs no preinstalled
-signing material and destroying it loses nothing that isn't recoverable.
+Nothing sensitive is baked into the VM, and nothing should be. Jobs that need
+signing material are expected to bring it themselves at run time and dispose of
+it afterwards, so the VM holds no credentials, needs no manual keychain setup,
+and can be destroyed and rebuilt without losing anything irrecoverable.
 
 ## Troubleshooting
 

--- a/home/dot_local/bin/executable_ci-vm-build
+++ b/home/dot_local/bin/executable_ci-vm-build
@@ -43,7 +43,9 @@ EOF
 : "${CI_VM_CPU:=6}"
 : "${CI_VM_MEMORY:=12288}"
 : "${CI_VM_DISK:=250}"
-: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+# No default on purpose: this repo is public, so which repo the runner
+# attaches to is machine configuration. Set it in ~/.config/ci-vm.conf.
+: "${CI_VM_REPO:=}"
 : "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
 : "${CI_VM_RUNNER_DIR:=actions-runner}"
 : "${CI_VM_USER:=admin}"
@@ -63,6 +65,14 @@ skip() { printf '\033[1;33m --\033[0m %s\n' "$*"; }
 die() {
   printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
   exit 1
+}
+
+# CI_VM_REPO has no built-in default (see above), so fail with an instruction
+# rather than letting an empty repo reach the API as a confusing 404.
+require_repo() {
+  [ -n "$CI_VM_REPO" ] || die "CI_VM_REPO is not set.
+     Add it to ${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf:
+       CI_VM_REPO=owner/repo"
 }
 
 need() {
@@ -120,6 +130,7 @@ need gh "brew install gh"
 need expect
 need ssh-copy-id
 
+require_repo
 gh auth status >/dev/null 2>&1 || die "gh is not authenticated — run: gh auth login"
 gh api "repos/$CI_VM_REPO" --jq .full_name >/dev/null 2>&1 ||
   die "cannot read repos/$CI_VM_REPO — check the repo name and the gh token scopes"

--- a/home/dot_local/bin/executable_ci-vm-destroy
+++ b/home/dot_local/bin/executable_ci-vm-destroy
@@ -31,7 +31,9 @@ EOF
   . "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf"
 
 : "${CI_VM_NAME:=ci-runner}"
-: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+# No default on purpose: this repo is public, so which repo the runner
+# attaches to is machine configuration. Set it in ~/.config/ci-vm.conf.
+: "${CI_VM_REPO:=}"
 : "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
 
 # --- Helpers ------------------------------------------------------------
@@ -41,6 +43,14 @@ skip() { printf '\033[1;33m --\033[0m %s\n' "$*"; }
 die() {
   printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
   exit 1
+}
+
+# CI_VM_REPO has no built-in default (see above), so fail with an instruction
+# rather than letting an empty repo reach the API as a confusing 404.
+require_repo() {
+  [ -n "$CI_VM_REPO" ] || die "CI_VM_REPO is not set.
+     Add it to ${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf:
+       CI_VM_REPO=owner/repo"
 }
 
 vm_state() {
@@ -74,6 +84,7 @@ while [ $# -gt 0 ]; do
 done
 
 command -v tart >/dev/null 2>&1 || die "tart is not installed"
+require_repo
 
 state="$(vm_state)"
 runner_id="$(runner_field .id)"

--- a/home/dot_local/bin/executable_ci-vm-down
+++ b/home/dot_local/bin/executable_ci-vm-down
@@ -30,7 +30,9 @@ EOF
   . "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf"
 
 : "${CI_VM_NAME:=ci-runner}"
-: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+# No default on purpose: this repo is public, so which repo the runner
+# attaches to is machine configuration. Set it in ~/.config/ci-vm.conf.
+: "${CI_VM_REPO:=}"
 : "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
 
 # --- Helpers ------------------------------------------------------------
@@ -39,6 +41,14 @@ log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 die() {
   printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
   exit 1
+}
+
+# CI_VM_REPO has no built-in default (see above), so fail with an instruction
+# rather than letting an empty repo reach the API as a confusing 404.
+require_repo() {
+  [ -n "$CI_VM_REPO" ] || die "CI_VM_REPO is not set.
+     Add it to ${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf:
+       CI_VM_REPO=owner/repo"
 }
 
 vm_state() {
@@ -91,6 +101,7 @@ if [ "$FORCE" -eq 1 ]; then
 elif ! command -v gh >/dev/null 2>&1; then
   die "gh is not installed, so the busy check cannot run — pass --force to stop anyway"
 else
+  require_repo
   busy="$(runner_field .busy)"
   if [ "$busy" = "true" ]; then
     die "runner '$CI_VM_RUNNER_NAME' is mid-job.

--- a/home/dot_local/bin/executable_ci-vm-up
+++ b/home/dot_local/bin/executable_ci-vm-up
@@ -30,7 +30,9 @@ EOF
   . "${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf"
 
 : "${CI_VM_NAME:=ci-runner}"
-: "${CI_VM_REPO:=pmgledhill102/lifeos}"
+# No default on purpose: this repo is public, so which repo the runner
+# attaches to is machine configuration. Set it in ~/.config/ci-vm.conf.
+: "${CI_VM_REPO:=}"
 : "${CI_VM_RUNNER_NAME:=$CI_VM_NAME}"
 : "${CI_VM_LOG_DIR:=${XDG_STATE_HOME:-$HOME/.local/state}/ci-vm}"
 : "${CI_VM_USER:=admin}"
@@ -42,6 +44,14 @@ log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 die() {
   printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
   exit 1
+}
+
+# CI_VM_REPO has no built-in default (see above), so fail with an instruction
+# rather than letting an empty repo reach the API as a confusing 404.
+require_repo() {
+  [ -n "$CI_VM_REPO" ] || die "CI_VM_REPO is not set.
+     Add it to ${XDG_CONFIG_HOME:-$HOME/.config}/ci-vm.conf:
+       CI_VM_REPO=owner/repo"
 }
 
 vm_state() {
@@ -130,6 +140,7 @@ fi
 # --- Wait for the runner ------------------------------------------------
 
 command -v gh >/dev/null 2>&1 || die "gh is not installed — cannot check runner status"
+require_repo
 
 # Belt and braces on the stale-status problem above: the LaunchAgent holding a
 # pid in the guest is proof the runner is alive in *this* boot, which no reading


### PR DESCRIPTION
Closes #380.

This repo is public. The runner VM docs added alongside the Tart work carried more about a private repo into it than they should have.

## What's removed

| Was | Now |
|---|---|
| Internal issue numbers paired with their subject matter — tying issues to CI running as the daily-use user with that user's keychain, and to the signing fix | Gone. The design rationale stays in generic form, since it's the reason the VM exists |
| A description of the signing flow (certificates from repo secrets into a throwaway keychain) | Generic statement that jobs bring their own signing material at run time and the VM holds no credentials |
| The private repo named and linked from README and docs, and identified as an iOS/macOS project shipping to TestFlight | Gone |
| Named workflows presented as PR gates | "If any such job is a required PR check" |
| `CI_VM_REPO` defaulting to the private repo in all four scripts | No default; required from `~/.config/ci-vm.conf` |

Verified by grepping the touched files for the project name and the issue-number patterns: no matches remain.

## `CI_VM_REPO` becoming required

This is the change with teeth, and it's better design independent of the privacy point — public dotfiles shouldn't hardcode one specific repo. A `require_repo` guard in each script fails with an instruction rather than letting an empty repo reach the API as a confusing 404:

```text
error: CI_VM_REPO is not set.
     Add it to /Users/paul/.config/ci-vm.conf:
       CI_VM_REPO=owner/repo
```

`~/.config/ci-vm.conf` is not chezmoi-managed (confirmed via `chezmoi managed`), so it stays local. It's already created on this machine, and `ci-vm-down`/`ci-vm-up` were re-run against the live VM after the change — the runner is up and online.

## Two things worth being straight about

- **Nothing secret was ever exposed.** No keys, tokens, certificates or runner server URLs were committed; registration tokens are fetched at runtime via `gh api` and passed over stdin. This is about inference, not credentials.
- **This reduces prominence, it doesn't undo disclosure.** The merged commits stay in history, and one earlier commit subject names the project. Genuinely removing it would need a history rewrite, which is disproportionate here — especially as the originating issue was already public in this repo.

ShellCheck and markdownlint clean.
