### PR TITLE
feat(ci): state and enforce that this repo is public and holds no private-repo references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
           # executable_*.ps1 would need excluding here.
           additional_files: 'executable_*'
 
+  private-repo-refs:
+    name: Private Repo References
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check for private repo references
+        # This repo is public by design (ADR-0014). Allowlist, not denylist —
+        # a list of private repo names committed here would leak the very
+        # thing it protects.
+        run: ./scripts/check-no-private-repos.sh
+
   markdown-lint:
     name: Markdown Lint
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -70,7 +82,7 @@ jobs:
   test-install-pr:
     name: Test Install on ${{ matrix.os }}
     if: github.event_name == 'pull_request'
-    needs: [shellcheck, markdown-lint, actionlint]
+    needs: [shellcheck, markdown-lint, actionlint, private-repo-refs]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -138,7 +150,7 @@ jobs:
   test-install:
     name: Test Install on ${{ matrix.os }}
     if: github.event_name != 'pull_request'
-    needs: [shellcheck, markdown-lint, actionlint]
+    needs: [shellcheck, markdown-lint, actionlint, private-repo-refs]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,15 @@ repos:
     hooks:
       - id: markdownlint-cli2
         # fix: true # Uncomment to auto-fix
+
+  # Layer 2 of ADR-0013 for ADR-0014: this repo is public, so private-repo
+  # references must not be committed. Scans the whole tree rather than the
+  # staged files, so it also catches a name that arrived some other way.
+  - repo: local
+    hooks:
+      - id: check-no-private-repos
+        name: No private repo references
+        entry: scripts/check-no-private-repos.sh
+        language: script
+        pass_filenames: false
+        always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,35 @@ Pre-commit hooks (`.pre-commit-config.yaml`) run markdownlint-cli2.
 Conventional commits: `<type>(<scope>): <description>`
 Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
 
+## This repository is public
+
+`dotfiles` is public, and has to be: the bootstrap is a single `curl` on a fresh
+machine, before any credential exists to authenticate with. Anything committed
+here is world-readable and indexed **permanently** — git history included, so
+deleting a line later does not unpublish it. The same applies to issues and pull
+requests on this repo.
+
+**Therefore: no direct references to private repositories.** Do not commit, and
+do not write in an issue or PR here:
+
+- the name or URL of a private repo;
+- its issue or PR numbers — especially paired with what they were about;
+- its workflow, job, or branch names;
+- its architecture, security arrangements, or release process;
+- anything identifying what a private project *is* or *does*.
+
+Tooling here may perfectly well **operate on** private repos — the CI runner VM
+scripts do. Make the repo an *input*, never a constant: read it from untracked
+machine config such as `~/.config/<tool>.conf`, with no default committed here.
+
+If a document genuinely needs private specifics, it belongs in the private
+personal-context repo, not this one.
+
+`scripts/check-no-private-repos.sh` enforces this in CI and pre-commit, against
+the allowlist in `scripts/public-repos.txt`. Reasoning: ADR-0014.
+
 ## Related repos
 
 - [`agentic-coding-config`](https://github.com/pmgledhill102/agentic-coding-config) — Claude Code commands/hooks/settings/MCP. Mounted at `~/.claude/` from this repo.
-- [`paul-context`](https://github.com/pmgledhill102/paul-context) — private personal context: principles, decisions, repo registry, direction.
+- A separate **private** repo holds personal context: principles, decisions, repo
+  registry, direction. Not named here, per the section above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,11 +62,32 @@ fix(install): correct Ubuntu package installation
 
 CI is defined in `.github/workflows/ci.yml`:
 
-- **PRs**: lint only — ShellCheck, markdownlint-cli2, actionlint (~2 min)
+- **PRs**: lint only — ShellCheck, markdownlint-cli2, actionlint, private-repo
+  reference check (~2 min)
 - **Push to main**: lint + full install test matrix (Ubuntu, macOS, Windows)
 - **Weekly / manual dispatch**: full install tests to catch upstream breakage
 
 Pre-commit hooks run markdownlint-cli2 locally.
+
+## This repository is public
+
+It has to be: the bootstrap is a single `curl` on a fresh machine, before any
+credential exists to authenticate with. So everything here is world-readable and
+indexed **permanently** — git history included, meaning a later deletion does
+not unpublish anything. Issue and PR bodies on this repo are public too.
+
+**No direct references to private repositories.** Not their names or URLs, not
+their issue numbers (especially paired with what they were about), not their
+workflow or branch names, not their architecture or release process.
+
+Tooling here may still *operate on* private repos — make the repo an input read
+from untracked machine config (`~/.config/<tool>.conf`), never a committed
+default. The `ci-vm-*` scripts work this way.
+
+`scripts/check-no-private-repos.sh` enforces this in CI and pre-commit against
+the allowlist in `scripts/public-repos.txt`. If it flags a repo that really is
+public, add its bare name to that file. Full reasoning in
+[ADR-0014](docs/adrs/0014-public-repo-no-private-references.md).
 
 ## Secrets
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Personal dotfiles managed by [chezmoi](https://www.chezmoi.io/). Provides a
 consistent dev environment across macOS, Linux, WSL, and Windows.
 
+> **This repository is public by design** — the bootstrap is a single `curl` on
+> a fresh machine, before any credential exists. Nothing here may reference a
+> private repository; tooling that operates on one reads it from untracked
+> machine config. See
+> [ADR-0014](docs/adrs/0014-public-repo-no-private-references.md).
+
 ## What You Get
 
 One curl command on a fresh machine and you walk away with a tuned shell, a

--- a/docs/adrs/0014-public-repo-no-private-references.md
+++ b/docs/adrs/0014-public-repo-no-private-references.md
@@ -1,0 +1,116 @@
+# ADR-0014: This repo is public by design; no private-repo references
+
+- **Status**: Accepted
+- **Date**: 2026-08-05
+- **Tags**: privacy, ci, quality
+
+## Context
+
+This repository is public, and not incidentally. The bootstrap is a single
+`curl` on a fresh machine — before any credential exists to authenticate with —
+so the install path cannot require auth. That constraint is load-bearing and is
+not going to change.
+
+The consequence is easy to state and easy to forget in the moment: everything
+committed here is world-readable and indexed **permanently**. Git history keeps
+what a later commit deletes, so removing a line does not unpublish it. The same
+applies to issue and pull request bodies on this repo, which are also public.
+
+The tooling here legitimately touches private work. The CI runner VM scripts
+(`ci-vm-*`) manage a self-hosted GitHub Actions runner that attaches to a
+private repo. When they were added, the docs, the README, the scripts' defaults,
+the issue and the pull request all named that repo, linked it, described what it
+builds and how it ships, and — the part that actually mattered — paired several
+of its internal issue numbers with their subject matter, including one about a
+security weakness and when it was fixed.
+
+No credentials were ever exposed. The problem was inference: the existence of a
+private project, what it is, and where it had been weak. Reviewing that led to a
+second finding, predating it — the private personal-context repo was named and
+linked from `CLAUDE.md`. So this is a recurring pattern, not a single lapse, and
+guidance alone had already failed to prevent it.
+
+## Decision
+
+**This repository is public by design, and must contain no direct references to
+private repositories.** Specifically, do not commit — and do not write in an
+issue or pull request here:
+
+- the name or URL of a private repo;
+- its issue or PR numbers, especially paired with what they were about;
+- its workflow, job, or branch names;
+- its architecture, security arrangements, or release process;
+- anything identifying what a private project *is* or *does*.
+
+Tooling here may **operate on** private repos. The repo must then be an *input*,
+never a constant: read it from untracked machine config such as
+`~/.config/<tool>.conf`, with no default committed here. `ci-vm-*` follows this
+— `CI_VM_REPO` has no default and the scripts fail with an instruction when it
+is unset.
+
+Documents that genuinely need private specifics belong in the private
+personal-context repo.
+
+### Enforcement
+
+Per ADR-0013, the same check runs at more than one layer, with CI authoritative:
+
+- **Layer 1 — CI.** A `Private repo references` job runs
+  `scripts/check-no-private-repos.sh` on every push and PR.
+- **Layer 2 — pre-commit.** The same script, as a local hook.
+- **Layer 3 — Claude Code hooks.** Not applicable here; those live in
+  `agentic-coding-config`, a separate repo.
+
+The check is an **allowlist**, and this is the crux of the design: a list of
+private repo names committed to a public repo would leak precisely the names it
+exists to protect. So the check flags every owner-scoped reference that is *not*
+in `scripts/public-repos.txt`. A newly created private repo is therefore caught
+with no action needed.
+
+An allowlist only sees owner-qualified references, not a bare project name on
+its own. The pre-commit layer additionally reads an optional untracked local
+file (`~/.config/dotfiles-private-names`) listing bare names to reject. That
+file never enters the repo; CI simply skips that half.
+
+## Consequences
+
+### Positive
+
+- The failure mode is caught mechanically rather than depending on whoever is
+  editing remembering the rule — which is what had already failed twice.
+- New private repos need no configuration to be protected.
+- Nothing sensitive is committed in service of protecting sensitive things.
+- Forcing the repo to be an input made `ci-vm-*` genuinely reusable, rather than
+  hardcoded to one project. The privacy fix and the design improvement were the
+  same change.
+
+### Negative / trade-offs
+
+- Public repos legitimately worth naming must be added to the allowlist, or the
+  check fails. Mild friction, and deliberately in the safe direction.
+- Bare-name detection depends on untracked local config, so it protects the
+  machine that has it and not CI. Accepted: the alternative is committing the
+  names.
+- Design notes about private work now live in two places, and the split has to
+  be maintained by hand.
+- This does not undo prior disclosure. The commits that named a private repo
+  remain in history, and one commit subject still does. Rewriting history was
+  considered and judged disproportionate.
+
+## Alternatives considered
+
+- **Denylist of private repo names.** Rejected outright: it publishes the list
+  of private repos to a public repo, which is the exact harm being prevented.
+- **Resolve visibility via the GitHub API in CI.** Attractive because it needs
+  no list at all, but a public repo's CI token cannot see private repos — a
+  private repo and a typo both return 404, so the signal is ambiguous. It also
+  makes the check network-dependent.
+- **Guidance only, no check.** This is what was already in place implicitly, and
+  it failed twice, including once immediately after the reviewer had been
+  primed on the risk.
+- **Make the repo private.** Impossible without breaking the credential-free
+  `curl` bootstrap, which is the reason it is public in the first place.
+- **Split into a private working repo and a public mirror.** Genuinely
+  attractive, and would move issues and history behind auth rather than
+  filtering their content. Larger structural change; not decided here, and this
+  ADR does not preclude it.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -44,3 +44,4 @@ Each ADR uses a short [MADR](https://adr.github.io/madr/)-style template:
 | [0011](0011-beads-task-tracking.md) | Beads with embedded Dolt for task tracking | Accepted |
 | [0012](0012-claude-code-config-via-dotfiles.md) | Claude Code configuration shipped via the dotfiles repo | Accepted |
 | [0013](0013-three-layer-enforcement.md) | Three-layer enforcement — CI, pre-commit, Claude Code hooks | Accepted |
+| [0014](0014-public-repo-no-private-references.md) | This repo is public by design; no private-repo references | Accepted |

--- a/scripts/check-no-private-repos.sh
+++ b/scripts/check-no-private-repos.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# check-no-private-repos.sh — keep private-repo references out of this public repo.
+#
+# This repository is public by necessity (ADR-0014). Naming a private repo here
+# publishes its existence permanently — git history included, so deleting the
+# line later does not unpublish it.
+#
+# Deliberately an ALLOWLIST, not a denylist: a list of private repo names
+# committed to a public repo would leak precisely the names it exists to
+# protect. Anything owner-scoped that is not in scripts/public-repos.txt fails,
+# so a new private repo is caught with no action needed.
+#
+# Optionally also greps for bare names in an untracked local file
+# (~/.config/dotfiles-private-names, one name per line). That catches references
+# carrying no owner prefix, which the allowlist cannot see. The file never
+# enters the repo, so CI simply skips this half.
+
+set -eu
+
+OWNER="${DOTFILES_REPO_OWNER:-pmgledhill102}"
+ALLOWLIST="${DOTFILES_PUBLIC_REPOS:-scripts/public-repos.txt}"
+LOCAL_NAMES="${DOTFILES_PRIVATE_NAMES:-${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles-private-names}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+[ -f "$ALLOWLIST" ] || {
+  printf 'error: allowlist not found at %s\n' "$ALLOWLIST" >&2
+  exit 1
+}
+
+violations="$(mktemp)"
+trap 'rm -f "$violations"' EXIT
+
+# --- Owner-scoped references --------------------------------------------
+
+# grep -o prints one match per line; -H keeps the filename on each.
+git ls-files -z |
+  xargs -0 grep -aoHE "$OWNER/[A-Za-z0-9._-]+" 2>/dev/null |
+  while IFS= read -r hit; do
+    file="${hit%%:*}"
+    name="${hit#*:}"
+    name="${name#"$OWNER"/}"
+    name="${name%.git}"
+    # The allowlist stores bare names, so it never matches this pattern itself.
+    grep -qxF "$name" "$ALLOWLIST" ||
+      printf '%s: names %s/%s, which is not on the public allowlist\n' \
+        "$file" "$OWNER" "$name"
+  done | sort -u >>"$violations"
+
+# --- Bare names from untracked local config -----------------------------
+
+if [ -f "$LOCAL_NAMES" ]; then
+  while IFS= read -r name || [ -n "$name" ]; do
+    case "$name" in '' | '#'*) continue ;; esac
+    git ls-files -z |
+      xargs -0 grep -ailF -- "$name" 2>/dev/null |
+      while IFS= read -r file; do
+        printf '%s: contains a name listed in %s\n' "$file" "$LOCAL_NAMES"
+      done | sort -u >>"$violations"
+  done <"$LOCAL_NAMES"
+fi
+
+# --- Report -------------------------------------------------------------
+
+if [ -s "$violations" ]; then
+  printf 'This repository is public — private-repo references must not be committed.\n\n' >&2
+  sed 's/^/  /' "$violations" >&2
+  printf '\nIf the repo named is public, add its bare name to %s.\n' "$ALLOWLIST" >&2
+  printf 'If it is private, make it an input instead: read it from untracked\n' >&2
+  printf 'machine config (e.g. ~/.config/<tool>.conf) with no default committed here.\n' >&2
+  printf 'See docs/adrs/0014-public-repo-no-private-references.md\n' >&2
+  exit 1
+fi
+
+echo "No private-repo references found."

--- a/scripts/public-repos.txt
+++ b/scripts/public-repos.txt
@@ -1,0 +1,8 @@
+# Repositories under this owner that may be named in this public repo.
+#
+# Bare names, one per line. Only add a repo here once it is genuinely public —
+# this file is the allowlist for scripts/check-no-private-repos.sh, and the
+# whole point is that private names never get committed. See
+# docs/adrs/0014-public-repo-no-private-references.md
+dotfiles
+agentic-coding-config


### PR DESCRIPTION
Closes #382. Follows #381, which cleaned up the instance that prompted this.

This repo is public by necessity — the bootstrap is a single `curl` on a fresh machine, before any credential exists to authenticate with. That constraint was never written down, and it has now been violated twice: by the CI runner VM docs, and earlier by `CLAUDE.md` naming and linking a private context repo. Guidance alone had already failed, so the rule is now both stated and checked.

## The rule

> Everything committed here is world-readable and indexed **permanently** — git history included, so deleting a line later does not unpublish it. Issue and PR bodies on this repo are public too.
>
> **No direct references to private repositories:** not their names or URLs, not their issue numbers (especially paired with what they were about), not their workflow or branch names, not their architecture or release process.
>
> Tooling here may **operate on** private repos. The repo must then be an *input*, never a constant: read from untracked machine config such as `~/.config/<tool>.conf`, with no default committed here.

## Where it lands

| File | Role |
|---|---|
| `docs/adrs/0014-…` | The decision and reasoning, in the repo's existing ADR format |
| `CLAUDE.md` | The layer that would actually have stopped me |
| `CONTRIBUTING.md` | The human path |
| `README.md` | A note up front, since that's what a reader meets first |
| `scripts/check-no-private-repos.sh` | Enforcement, wired into CI and pre-commit per ADR-0013 |

## Why it's an allowlist

This is the crux. **A list of private repo names committed to a public repo would leak precisely the names it exists to protect.** So the check flags every owner-scoped reference *not* in `scripts/public-repos.txt` (currently just `dotfiles` and `agentic-coding-config`). A newly created private repo is therefore covered with no action needed.

An allowlist can only see owner-qualified references, not a bare project name. The pre-commit layer additionally reads an optional **untracked** local file (`~/.config/dotfiles-private-names`), so those names live on the machine and never enter the repo. CI has no such file and simply skips that half — which is the correct behaviour, not a gap to close.

## Verified, including the failure paths

A check that only ever passes proves nothing, so:

1. Clean tree → passes.
2. Planted `github.com/pmgledhill102/some-private-thing` in a doc → **caught**, named the file and the offending reference.
3. Added a bare name to an untracked local list and referenced it → **caught** by the second detector.
4. Reverted → passes again.

It also earned its keep on first run by flagging the pre-existing private context repo link in `CLAUDE.md` — now generalised, keeping the concept without the name. That reference predates this work and would not have been found by hand.

ShellCheck, markdownlint, actionlint and the new pre-commit hook all clean locally.

## Not covered

- **Issue and PR bodies.** Stated as discipline in the rule; not mechanically enforceable from repo content.
- **Prior disclosure.** History still contains the earlier references, and one commit subject names a private repo. A rewrite was considered and judged disproportionate — recorded in the ADR rather than left implicit.
- **`agentic-coding-config`** is public and has the same exposure. Cross-repo, so it gets an issue there rather than an edit from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)