### PR TITLE
chore(brew): add Atlassian CLI to personal and work machines

### DIFF
--- a/home/Brewfile.tmpl
+++ b/home/Brewfile.tmpl
@@ -2,12 +2,13 @@
 # To add/remove packages, edit this file directly
 
 {{- if eq .machine_type "personal" }}
-tap "aws/tap"
+tap "atlassian/acli"
 tap "cirruslabs/cli"
 tap "terraform-linters/tap"
 
 brew "actionlint"
 brew "aria2"
+brew "atlassian/acli/acli"
 brew "aws-sam-cli"
 brew "awscli"
 brew "azure-cli"
@@ -94,9 +95,11 @@ cask "visual-studio-code"
 cask "voiceink"
 cask "whatsapp"
 {{- else if eq .machine_type "work" }}
+tap "atlassian/acli"
 tap "terraform-linters/tap"
 
 brew "actionlint"
+brew "atlassian/acli/acli"
 brew "bat"
 brew "checkov"
 brew "cspell"


### PR DESCRIPTION
## Summary
Adds the Atlassian CLI (`acli`) package to both personal and work machine configurations, replacing the AWS tap on personal machines with the Atlassian CLI tap.

## Changes
- **Personal machines**: Replace `aws/tap` with `atlassian/acli` tap and add `atlassian/acli/acli` brew package
- **Work machines**: Add `atlassian/acli` tap and `atlassian/acli/acli` brew package

## Details
The Atlassian CLI is now installed on both machine types via Homebrew. On personal machines, this replaces the previous AWS tap dependency (AWS CLI is still installed via the `awscli` package). The tap and package are added in the appropriate conditional sections of the Brewfile template.

https://claude.ai/code/session_019V1gX71VrrAYgw28CiPbDe