### PR TITLE
feat(zsh): suppress known-noisy Homebrew warnings in brewup

### DIFF
--- a/home/dot_config/zsh/functions/brewup.zsh
+++ b/home/dot_config/zsh/functions/brewup.zsh
@@ -2,6 +2,25 @@
 # shellcheck shell=bash
 # Update Homebrew + Brewfile, then any non-brew package managers (rustup)
 
+# Homebrew has no env var to silence these: they're printed unconditionally
+# via opoo (stderr) for anyone not in HOMEBREW_DEVELOPER mode, and upstream
+# taps (e.g. cirruslabs/homebrew-cli) own the fix, not us. Drop the specific
+# warning paragraphs (up to the next blank line); everything else, including
+# real errors, passes through untouched. BREWUP_SHOW_WARNINGS=1 disables this.
+_brewup_filter_noise() {
+  if [ "$BREWUP_SHOW_WARNINGS" = "1" ]; then
+    cat
+    return
+  fi
+  awk '
+    /^Warning: Calling `.*`.*(is deprecated|is disabled)!/ { skip = 1; next }
+    /^Warning: Formulae dependency graph sorting found a circular dependency:/ { skip = 1; next }
+    skip && NF == 0 { skip = 0; next }
+    skip { next }
+    { print }
+  '
+}
+
 brewup() {
   if ! command -v brew >/dev/null 2>&1; then
     echo "Error: Homebrew is not installed."
@@ -9,7 +28,7 @@ brewup() {
   fi
 
   echo "==> Updating Homebrew..."
-  brew update
+  brew update 2> >(_brewup_filter_noise >&2)
 
   local brewfile="$HOME/Brewfile"
   if [ -f "$brewfile" ]; then
@@ -27,13 +46,13 @@ brewup() {
     # HOMEBREW_BUNDLE_JOBS=1: Homebrew 6's parallel installer (default 'auto')
     # has lock races on shared dependencies (Homebrew/brew#23328); sequential
     # is the pre-brew-6 behavior. Revisit: dotfiles#368.
-    HOMEBREW_NO_ASK=1 HOMEBREW_BUNDLE_JOBS=1 brew bundle install --file "$brewfile"
+    HOMEBREW_NO_ASK=1 HOMEBREW_BUNDLE_JOBS=1 brew bundle install --file "$brewfile" 2> >(_brewup_filter_noise >&2)
   else
     echo "Warning: Brewfile not found at $brewfile"
   fi
 
   printf "\n==> Upgrading installed packages...\n"
-  HOMEBREW_NO_ASK=1 brew upgrade
+  HOMEBREW_NO_ASK=1 brew upgrade 2> >(_brewup_filter_noise >&2)
 
   # Rust isn't in the Brewfile (rustup manages its own toolchain channel),
   # but it IS a package-manager update, which is brewup's remit. Belongs


### PR DESCRIPTION
## Summary
- `brewup` output was dominated by warnings the user can't act on: upstream tap DSL deprecations (e.g. `cirruslabs/homebrew-cli`'s `depends_on macos:` syntax) and stale-keg circular-dependency notices. Homebrew has no env var to gate these off (`HOMEBREW_DEVELOPER` only escalates them to hard errors).
- Both are emitted via `opoo` on stderr only, so they can be filtered without touching stdout or real errors. Added an `awk` paragraph-filter (`_brewup_filter_noise`) applied to `brew update`, `brew bundle install`, and `brew upgrade` via `2> >(...)` process substitution, which drops known warning blocks up to the next blank line and passes everything else through.
- `BREWUP_SHOW_WARNINGS=1` restores full output, matching the existing `BREWUP_SKIP_RUST` opt-out pattern already in this file.

Closes #390

## Test plan
- [x] `shellcheck home/dot_config/zsh/functions/brewup.zsh` — clean
- [x] Sourced the file and piped a synthetic stderr sample (both warning blocks + a real `Error:` line) through `_brewup_filter_noise` — warnings dropped, error preserved
- [x] Re-ran with `BREWUP_SHOW_WARNINGS=1` — full output restored
